### PR TITLE
feat(confirmation): add "It was me / It wasn't me" signed login confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,20 +210,146 @@ final class NewDeviceListener
 
 > **Note:** Persistence and notification are handled automatically by the bundle. You do **not** need to listen to this event for the bundle to work.
 
+## Login Confirmation ("It was me / It wasn't me")
+
+This optional feature adds two **signed links** to the notification email so the user can confirm the login was theirs — or report that it wasn't — from any device, without being logged in.
+
+- The links are signed with your application secret and carry an expiration.
+- Clicking a link opens an intermediate page with a confirmation button that **POSTs** the action. This prevents email link scanners (Outlook Safe Links, etc.) from triggering the action just by following the URL.
+- A link is **single-use**: once the login is acknowledged or disavowed, replaying it shows an "already handled" page.
+
+The bundle only records the outcome and **dispatches an event** — your application decides what to do next (e.g. force a password change or log out other sessions on a disavow).
+
+### 1. Enable the feature
+
+```yaml
+spiriit_auth_log:
+    confirmation:
+        enabled: true
+        token_ttl: '3 days'   # relative expression: "12 hours", "1 week"...
+```
+
+Generating absolute URLs from a Messenger worker (no request context) requires a default URI:
+
+```yaml
+# config/packages/routing.yaml
+framework:
+    router:
+        default_uri: 'https://your-domain.com'
+```
+
+### 2. Make your log entity confirmable
+
+Add the trait and interface to the entity that already extends `AbstractAuthenticationLog`, then generate a migration for the new columns (`confirmation_token`, `status`, `responded_at`):
+
+```php
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogTrait;
+
+#[ORM\Entity(repositoryClass: UserAuthLogRepository::class)]
+class UserAuthLog extends AbstractAuthenticationLog implements ConfirmableAuthenticationLogInterface
+{
+    use ConfirmableAuthenticationLogTrait;
+
+    // ... your existing fields
+}
+```
+
+> If you don't enable the feature, nothing changes: the trait and columns are opt-in, so existing integrators don't need a migration.
+
+### 3. Implement the confirmable repository
+
+```php
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
+
+class UserAuthLogRepository extends EntityRepository implements
+    AuthenticationLogRepositoryInterface,
+    AuthenticationLogCreatorInterface,
+    ConfirmableAuthenticationLogRepositoryInterface
+{
+    // ... existing methods
+
+    public function findOneByConfirmationToken(string $confirmationToken): ?ConfirmableAuthenticationLogInterface
+    {
+        return $this->findOneBy(['confirmationToken' => $confirmationToken]);
+    }
+}
+```
+
+### 4. Expose the confirmation route
+
+You keep full control over the route. Pick one of the two approaches.
+
+**a. Import the default route** (simplest). You may add a `prefix`, `host` or `condition` — the generated links follow it automatically:
+
+```yaml
+# config/routes/spiriit_auth_log.yaml
+spiriit_auth_log:
+    resource: '@SpiriitAuthLogBundle/config/routes.php'
+    prefix: /security   # optional
+```
+
+**b. Declare your own route** and point the bundle at it — use this when you want your own path or format:
+
+```yaml
+# config/routes.yaml
+my_login_confirmation:
+    path: /account/logins/{action}/{token}
+    controller: spiriit_auth_log.confirmation_controller
+    methods: [GET, POST]
+    requirements: { action: 'acknowledge|disavow' }
+```
+
+```yaml
+spiriit_auth_log:
+    confirmation:
+        enabled: true
+        route_name: my_login_confirmation   # defaults to "spiriit_auth_log_confirm"
+```
+
+### 5. React to the user's response
+
+The bundle dispatches `AuthenticationLogEvents::LOGIN_ACKNOWLEDGED` or `AuthenticationLogEvents::LOGIN_DISAVOWED`, carrying the confirmed log:
+
+```php
+use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogConfirmationEvent;
+use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogEvents;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: AuthenticationLogEvents::LOGIN_DISAVOWED)]
+final class LoginDisavowedListener
+{
+    public function __invoke(AuthenticationLogConfirmationEvent $event): void
+    {
+        $log = $event->authenticationLog();
+        $user = $log->getUser();
+
+        // e.g. force a password reset, invalidate sessions, notify security...
+    }
+}
+```
+
+You can override the confirmation pages the same way as the email template, under
+`templates/bundles/SpiriitAuthLogBundle/confirmation/`.
+
 ## Custom Notification
 
 By default, the bundle sends email alerts via Symfony Mailer. To use a different transport (Slack, SMS, etc.), implement `NotificationInterface` and register it as a service:
 
 ```php
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
 use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
 
 final class SlackNotification implements NotificationInterface
 {
-    public function send(UserInformation $userInformation, UserReference $userReference): void
+    public function send(UserInformation $userInformation, UserReference $userReference, ?ConfirmationLinks $confirmationLinks = null): void
     {
         // send a Slack message, SMS, etc.
+        // $confirmationLinks is null unless the confirmation feature is enabled
     }
 }
 ```
@@ -260,6 +386,7 @@ Available variables in the template:
 | `userInformation.location` | `?LocateValues` | Geolocation (city, country, latitude, longitude) |
 | `authenticableLog.displayName` | `string` | User display name |
 | `authenticableLog.email` | `string` | User email |
+| `confirmationLinks` | `?ConfirmationLinks` | `acknowledgeUrl` / `disavowUrl` — only set when the confirmation feature is enabled |
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Your repository must implement two interfaces:
 ```php
 use Doctrine\ORM\EntityRepository;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogCreatorInterface;
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
 
@@ -125,7 +125,7 @@ class UserAuthLogRepository extends EntityRepository implements
     AuthenticationLogRepositoryInterface,
     AuthenticationLogCreatorInterface
 {
-    public function save(AbstractAuthenticationLog $log): void
+    public function save(AuthenticationLogInterface $log): void
     {
         $this->getEntityManager()->persist($log);
         $this->getEntityManager()->flush();
@@ -139,7 +139,7 @@ class UserAuthLogRepository extends EntityRepository implements
         ]);
     }
 
-    public function createLog(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog
+    public function createLog(string $userIdentifier, UserInformation $userInformation): AuthenticationLogInterface
     {
         $user = $this->getEntityManager()->getRepository(User::class)->findOneBy([
             'email' => $userIdentifier,

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ This optional feature adds two **signed links** to the notification email so the
 - The links are signed with your application secret and carry an expiration.
 - Clicking a link opens an intermediate page with a confirmation button that **POSTs** the action. This prevents email link scanners (Outlook Safe Links, etc.) from triggering the action just by following the URL.
 - A link is **single-use**: once the login is acknowledged or disavowed, replaying it shows an "already handled" page.
+- If the login no longer exists (e.g. it was pruned by your retention policy), the page reports that the link is no longer valid, with a `404` status — distinct from the "already handled" page.
 
 The bundle only records the outcome and **dispatches an event** — your application decides what to do next (e.g. force a password change or log out other sessions on a disavow).
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 Release 2.1 introduces the optional login-confirmation feature ("It was me / It wasn't me"). As part of it, the bundle's persistence contract no longer references the concrete `AbstractAuthenticationLog` mapped superclass — it now depends on the new `AuthenticationLogInterface`. This decouples the contract from Doctrine inheritance: an integrator can implement a log without extending the mapped superclass.
 
-`AbstractAuthenticationLog` implements `AuthenticationLogInterface`, so your entity needs **no change**. Only your repository signatures must be widened.
+`AbstractAuthenticationLog` implements `AuthenticationLogInterface`, so your log entity needs **no change**. What must change are the signatures of the bundle interfaces you implement — an incompatible signature is a fatal error at class load, so update every interface you have implemented.
 
 ### 1. Repository: widen `save()` and `createLog()` (required)
 
@@ -54,6 +54,51 @@ class UserAuthLogRepository extends EntityRepository implements
 }
 ```
 
+### 2. Custom notification: accept the confirmation links parameter
+
+If you implemented `NotificationInterface` for a custom transport (Slack, SMS…), `send()` now takes a third optional argument, `?ConfirmationLinks $confirmationLinks = null`. It carries the "It was me / It wasn't me" links when the confirmation feature is enabled, and is `null` otherwise. Omitting it is a fatal signature error.
+
+**Before:**
+
+```php
+use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
+
+final class SlackNotification implements NotificationInterface
+{
+    public function send(UserInformation $userInformation, UserReference $userReference): void
+    {
+        // ...
+    }
+}
+```
+
+**After:**
+
+```php
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
+use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
+
+final class SlackNotification implements NotificationInterface
+{
+    public function send(UserInformation $userInformation, UserReference $userReference, ?ConfirmationLinks $confirmationLinks = null): void
+    {
+        // Use $confirmationLinks->acknowledgeUrl / ->disavowUrl when not null
+    }
+}
+```
+
+### 3. Custom handler (advanced): `handle()` now returns the log
+
+Only relevant if you replaced the bundle's default `DoctrineAuthenticationLogHandler` with your own `AuthenticationLogHandlerInterface` implementation. `handle()` no longer returns `void` — it returns the persisted `AuthenticationLogInterface` (so the caller can pass it to the notification). Return the log you saved.
+
+```php
+// Before
+public function handle(string $userIdentifier, UserInformation $userInformation): void
+
+// After
+public function handle(string $userIdentifier, UserInformation $userInformation): AuthenticationLogInterface
+```
+
 ### Summary of Changed Interfaces
 
 | Interface | Change |
@@ -61,6 +106,8 @@ class UserAuthLogRepository extends EntityRepository implements
 | `AuthenticationLogInterface` | **New.** Abstraction for an authentication log (`getUser()` + read accessors). `AbstractAuthenticationLog` implements it |
 | `AuthenticationLogRepositoryInterface` | `save()` now type-hints `AuthenticationLogInterface` instead of `AbstractAuthenticationLog` |
 | `AuthenticationLogCreatorInterface` | `createLog()` now returns `AuthenticationLogInterface` |
+| `NotificationInterface` | `send()` gains a third argument `?ConfirmationLinks $confirmationLinks = null` |
+| `AuthenticationLogHandlerInterface` | `handle()` now returns `AuthenticationLogInterface` (was `void`) — advanced, only if you replaced the default handler |
 
 ## Upgrading from 1.x to 2.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,67 @@
 # Upgrade Guide
 
+## Upgrading from 2.0 to 2.1
+
+Release 2.1 introduces the optional login-confirmation feature ("It was me / It wasn't me"). As part of it, the bundle's persistence contract no longer references the concrete `AbstractAuthenticationLog` mapped superclass — it now depends on the new `AuthenticationLogInterface`. This decouples the contract from Doctrine inheritance: an integrator can implement a log without extending the mapped superclass.
+
+`AbstractAuthenticationLog` implements `AuthenticationLogInterface`, so your entity needs **no change**. Only your repository signatures must be widened.
+
+### 1. Repository: widen `save()` and `createLog()` (required)
+
+`AuthenticationLogRepositoryInterface::save()` and `AuthenticationLogCreatorInterface::createLog()` now type-hint `AuthenticationLogInterface`. A parameter type cannot be narrowed in an implementation, so keeping `AbstractAuthenticationLog` triggers a fatal error — update the signatures.
+
+**Before:**
+
+```php
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+
+class UserAuthLogRepository extends EntityRepository implements
+    AuthenticationLogRepositoryInterface,
+    AuthenticationLogCreatorInterface
+{
+    public function save(AbstractAuthenticationLog $log): void
+    {
+        $this->getEntityManager()->persist($log);
+        $this->getEntityManager()->flush();
+    }
+
+    public function createLog(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog
+    {
+        return new UserAuthLog($userIdentifier, $userInformation);
+    }
+}
+```
+
+**After:**
+
+```php
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
+
+class UserAuthLogRepository extends EntityRepository implements
+    AuthenticationLogRepositoryInterface,
+    AuthenticationLogCreatorInterface
+{
+    public function save(AuthenticationLogInterface $log): void
+    {
+        $this->getEntityManager()->persist($log);
+        $this->getEntityManager()->flush();
+    }
+
+    public function createLog(string $userIdentifier, UserInformation $userInformation): AuthenticationLogInterface
+    {
+        return new UserAuthLog($userIdentifier, $userInformation);
+    }
+}
+```
+
+### Summary of Changed Interfaces
+
+| Interface | Change |
+|---|---|
+| `AuthenticationLogInterface` | **New.** Abstraction for an authentication log (`getUser()` + read accessors). `AbstractAuthenticationLog` implements it |
+| `AuthenticationLogRepositoryInterface` | `save()` now type-hints `AuthenticationLogInterface` instead of `AbstractAuthenticationLog` |
+| `AuthenticationLogCreatorInterface` | `createLog()` now returns `AuthenticationLogInterface` |
+
 ## Upgrading from 1.x to 2.0
 
 This is a major release with breaking changes. Follow this guide step by step.

--- a/config/confirmation.php
+++ b/config/confirmation.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationTokenGenerator;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationUrlGenerator;
+use Spiriit\Bundle\AuthLogBundle\Controller\AuthenticationLogConfirmationController;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
+
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services();
+
+    $services->set('spiriit_auth_log.confirmation_token_generator', ConfirmationTokenGenerator::class);
+
+    $services->set('spiriit_auth_log.confirmation_url_generator', ConfirmationUrlGenerator::class)
+        ->args([
+            service('router'),
+            service('uri_signer'),
+            '%spiriit_auth_log.confirmation.route_name%',
+            '%spiriit_auth_log.confirmation.token_ttl%',
+        ]);
+
+    $services->set('spiriit_auth_log.confirmation_controller', AuthenticationLogConfirmationController::class)
+        ->args([
+            service('uri_signer'),
+            service(ConfirmableAuthenticationLogRepositoryInterface::class),
+            service('event_dispatcher'),
+            service('twig'),
+        ])
+        ->public()
+        ->tag('controller.service_arguments');
+};

--- a/config/new_device.php
+++ b/config/new_device.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Spiriit\Bundle\AuthLogBundle\Listener\LoginListener;
+use Spiriit\Bundle\AuthLogBundle\Notification\NewDeviceNotifier;
 use Spiriit\Bundle\AuthLogBundle\Services\LoginService;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
@@ -20,11 +21,16 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
+    $services->set('spiriit_auth_log.new_device_notifier', NewDeviceNotifier::class)
+        ->args([
+            service('spiriit_auth_log.notification'),
+        ]);
+
     $services->set('spiriit_auth_log.login_service', LoginService::class)
         ->args([
             service('spiriit_auth_log.fetch_user_information'),
             service('spiriit_auth_log.handler'),
-            service('spiriit_auth_log.notification'),
+            service('spiriit_auth_log.new_device_notifier'),
             service('spiriit_auth_log.login_event_dispatcher'),
         ]);
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+/*
+ * Optional default route for the confirmation feature. Import it from your app
+ * (optionally with a "prefix") to get a ready-to-use route, or declare your own
+ * route pointing to "spiriit_auth_log.confirmation_controller" and set
+ * "spiriit_auth_log.confirmation.route_name" to its name instead.
+ */
+return static function (RoutingConfigurator $routes): void {
+    $routes->add('spiriit_auth_log_confirm', '/auth-log/confirm/{action}/{token}')
+        ->controller('spiriit_auth_log.confirmation_controller')
+        ->methods(['GET', 'POST'])
+        ->requirements(['action' => 'acknowledge|disavow']);
+};

--- a/src/AuthenticationLog/AuthenticationLogCreatorInterface.php
+++ b/src/AuthenticationLog/AuthenticationLogCreatorInterface.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\AuthenticationLog;
 
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 
 interface AuthenticationLogCreatorInterface
 {
-    public function createLog(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog;
+    public function createLog(string $userIdentifier, UserInformation $userInformation): AuthenticationLogInterface;
 }

--- a/src/AuthenticationLog/AuthenticationLogHandlerInterface.php
+++ b/src/AuthenticationLog/AuthenticationLogHandlerInterface.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\AuthenticationLog;
 
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 
 interface AuthenticationLogHandlerInterface
 {
     public function isKnown(string $userIdentifier, UserInformation $userInformation): bool;
 
-    public function handle(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog;
+    public function handle(string $userIdentifier, UserInformation $userInformation): AuthenticationLogInterface;
 }

--- a/src/AuthenticationLog/AuthenticationLogHandlerInterface.php
+++ b/src/AuthenticationLog/AuthenticationLogHandlerInterface.php
@@ -11,11 +11,12 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\AuthenticationLog;
 
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 
 interface AuthenticationLogHandlerInterface
 {
     public function isKnown(string $userIdentifier, UserInformation $userInformation): bool;
 
-    public function handle(string $userIdentifier, UserInformation $userInformation): void;
+    public function handle(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog;
 }

--- a/src/AuthenticationLog/DoctrineAuthenticationLogHandler.php
+++ b/src/AuthenticationLog/DoctrineAuthenticationLogHandler.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\AuthenticationLog;
 
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationTokenGenerator;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
 
@@ -19,6 +22,7 @@ final readonly class DoctrineAuthenticationLogHandler implements AuthenticationL
     public function __construct(
         private AuthenticationLogRepositoryInterface $repository,
         private AuthenticationLogCreatorInterface $creator,
+        private ?ConfirmationTokenGenerator $confirmationTokenGenerator = null,
     ) {
     }
 
@@ -27,9 +31,16 @@ final readonly class DoctrineAuthenticationLogHandler implements AuthenticationL
         return $this->repository->findExistingLog($userIdentifier, $userInformation);
     }
 
-    public function handle(string $userIdentifier, UserInformation $userInformation): void
+    public function handle(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog
     {
         $log = $this->creator->createLog($userIdentifier, $userInformation);
+
+        if (null !== $this->confirmationTokenGenerator && $log instanceof ConfirmableAuthenticationLogInterface) {
+            $log->enableConfirmation($this->confirmationTokenGenerator->generate());
+        }
+
         $this->repository->save($log);
+
+        return $log;
     }
 }

--- a/src/AuthenticationLog/DoctrineAuthenticationLogHandler.php
+++ b/src/AuthenticationLog/DoctrineAuthenticationLogHandler.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Spiriit\Bundle\AuthLogBundle\AuthenticationLog;
 
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationTokenGenerator;
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
@@ -31,7 +31,7 @@ final readonly class DoctrineAuthenticationLogHandler implements AuthenticationL
         return $this->repository->findExistingLog($userIdentifier, $userInformation);
     }
 
-    public function handle(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog
+    public function handle(string $userIdentifier, UserInformation $userInformation): AuthenticationLogInterface
     {
         $log = $this->creator->createLog($userIdentifier, $userInformation);
 

--- a/src/Confirmation/ConfirmationAction.php
+++ b/src/Confirmation/ConfirmationAction.php
@@ -9,13 +9,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Spiriit\Bundle\AuthLogBundle\Listener;
+namespace Spiriit\Bundle\AuthLogBundle\Confirmation;
 
-class AuthenticationLogEvents
+enum ConfirmationAction: string
 {
-    public const NEW_DEVICE = 'spiriit.auth_log.new_device';
-
-    public const LOGIN_ACKNOWLEDGED = 'spiriit.auth_log.login_acknowledged';
-
-    public const LOGIN_DISAVOWED = 'spiriit.auth_log.login_disavowed';
+    case ACKNOWLEDGE = 'acknowledge';
+    case DISAVOW = 'disavow';
 }

--- a/src/Confirmation/ConfirmationLinks.php
+++ b/src/Confirmation/ConfirmationLinks.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Spiriit\Bundle\AuthLogBundle\Listener;
+namespace Spiriit\Bundle\AuthLogBundle\Confirmation;
 
-class AuthenticationLogEvents
+final readonly class ConfirmationLinks
 {
-    public const NEW_DEVICE = 'spiriit.auth_log.new_device';
-
-    public const LOGIN_ACKNOWLEDGED = 'spiriit.auth_log.login_acknowledged';
-
-    public const LOGIN_DISAVOWED = 'spiriit.auth_log.login_disavowed';
+    public function __construct(
+        public string $acknowledgeUrl,
+        public string $disavowUrl,
+    ) {
+    }
 }

--- a/src/Confirmation/ConfirmationToken.php
+++ b/src/Confirmation/ConfirmationToken.php
@@ -9,13 +9,17 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Spiriit\Bundle\AuthLogBundle\Listener;
+namespace Spiriit\Bundle\AuthLogBundle\Confirmation;
 
-class AuthenticationLogEvents
+final readonly class ConfirmationToken
 {
-    public const NEW_DEVICE = 'spiriit.auth_log.new_device';
+    public function __construct(
+        private string $value,
+    ) {
+    }
 
-    public const LOGIN_ACKNOWLEDGED = 'spiriit.auth_log.login_acknowledged';
-
-    public const LOGIN_DISAVOWED = 'spiriit.auth_log.login_disavowed';
+    public function toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/src/Confirmation/ConfirmationTokenGenerator.php
+++ b/src/Confirmation/ConfirmationTokenGenerator.php
@@ -9,13 +9,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Spiriit\Bundle\AuthLogBundle\Listener;
+namespace Spiriit\Bundle\AuthLogBundle\Confirmation;
 
-class AuthenticationLogEvents
+use Symfony\Component\String\ByteString;
+
+final class ConfirmationTokenGenerator
 {
-    public const NEW_DEVICE = 'spiriit.auth_log.new_device';
-
-    public const LOGIN_ACKNOWLEDGED = 'spiriit.auth_log.login_acknowledged';
-
-    public const LOGIN_DISAVOWED = 'spiriit.auth_log.login_disavowed';
+    public function generate(): ConfirmationToken
+    {
+        return new ConfirmationToken(ByteString::fromRandom(32)->toString());
+    }
 }

--- a/src/Confirmation/ConfirmationUrlGenerator.php
+++ b/src/Confirmation/ConfirmationUrlGenerator.php
@@ -34,20 +34,22 @@ final readonly class ConfirmationUrlGenerator
             throw new ConfirmationNotEnabledException('Cannot generate confirmation links for a log whose confirmation has not been enabled.');
         }
 
+        $expiresAt = (new \DateTimeImmutable('+'.$this->tokenTtl))->getTimestamp();
+
         return new ConfirmationLinks(
-            acknowledgeUrl: $this->signedUrl($token, ConfirmationAction::ACKNOWLEDGE),
-            disavowUrl: $this->signedUrl($token, ConfirmationAction::DISAVOW),
+            acknowledgeUrl: $this->signedUrl($token, $expiresAt, ConfirmationAction::ACKNOWLEDGE),
+            disavowUrl: $this->signedUrl($token, $expiresAt, ConfirmationAction::DISAVOW),
         );
     }
 
-    private function signedUrl(string $token, ConfirmationAction $action): string
+    private function signedUrl(string $token, int $expiresAt, ConfirmationAction $action): string
     {
         $url = $this->urlGenerator->generate(
             $this->routeName,
             [
                 'action' => $action->value,
                 'token' => $token,
-                'expires' => (new \DateTimeImmutable('+'.$this->tokenTtl))->getTimestamp(),
+                'expires' => $expiresAt,
             ],
             UrlGeneratorInterface::ABSOLUTE_URL,
         );

--- a/src/Confirmation/ConfirmationUrlGenerator.php
+++ b/src/Confirmation/ConfirmationUrlGenerator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Confirmation;
+
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class ConfirmationUrlGenerator
+{
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+        private UriSigner $uriSigner,
+        private string $routeName,
+        private string $tokenTtl,
+    ) {
+    }
+
+    public function generate(ConfirmableAuthenticationLogInterface $authenticationLog): ConfirmationLinks
+    {
+        return new ConfirmationLinks(
+            acknowledgeUrl: $this->signedUrl($authenticationLog, ConfirmationAction::ACKNOWLEDGE),
+            disavowUrl: $this->signedUrl($authenticationLog, ConfirmationAction::DISAVOW),
+        );
+    }
+
+    private function signedUrl(ConfirmableAuthenticationLogInterface $authenticationLog, ConfirmationAction $action): string
+    {
+        $url = $this->urlGenerator->generate(
+            $this->routeName,
+            [
+                'action' => $action->value,
+                'token' => $authenticationLog->confirmationToken(),
+                'expires' => (new \DateTimeImmutable('+'.$this->tokenTtl))->getTimestamp(),
+            ],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        return $this->uriSigner->sign($url);
+    }
+}

--- a/src/Confirmation/ConfirmationUrlGenerator.php
+++ b/src/Confirmation/ConfirmationUrlGenerator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\Confirmation;
 
+use Spiriit\Bundle\AuthLogBundle\Confirmation\Exception\ConfirmationNotEnabledException;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -27,19 +28,25 @@ final readonly class ConfirmationUrlGenerator
 
     public function generate(ConfirmableAuthenticationLogInterface $authenticationLog): ConfirmationLinks
     {
+        $token = $authenticationLog->confirmationToken();
+
+        if (null === $token) {
+            throw new ConfirmationNotEnabledException('Cannot generate confirmation links for a log whose confirmation has not been enabled.');
+        }
+
         return new ConfirmationLinks(
-            acknowledgeUrl: $this->signedUrl($authenticationLog, ConfirmationAction::ACKNOWLEDGE),
-            disavowUrl: $this->signedUrl($authenticationLog, ConfirmationAction::DISAVOW),
+            acknowledgeUrl: $this->signedUrl($token, ConfirmationAction::ACKNOWLEDGE),
+            disavowUrl: $this->signedUrl($token, ConfirmationAction::DISAVOW),
         );
     }
 
-    private function signedUrl(ConfirmableAuthenticationLogInterface $authenticationLog, ConfirmationAction $action): string
+    private function signedUrl(string $token, ConfirmationAction $action): string
     {
         $url = $this->urlGenerator->generate(
             $this->routeName,
             [
                 'action' => $action->value,
-                'token' => $authenticationLog->confirmationToken(),
+                'token' => $token,
                 'expires' => (new \DateTimeImmutable('+'.$this->tokenTtl))->getTimestamp(),
             ],
             UrlGeneratorInterface::ABSOLUTE_URL,

--- a/src/Confirmation/Exception/AuthenticationLogAlreadyReviewedException.php
+++ b/src/Confirmation/Exception/AuthenticationLogAlreadyReviewedException.php
@@ -9,13 +9,8 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Spiriit\Bundle\AuthLogBundle\Listener;
+namespace Spiriit\Bundle\AuthLogBundle\Confirmation\Exception;
 
-class AuthenticationLogEvents
+final class AuthenticationLogAlreadyReviewedException extends \RuntimeException
 {
-    public const NEW_DEVICE = 'spiriit.auth_log.new_device';
-
-    public const LOGIN_ACKNOWLEDGED = 'spiriit.auth_log.login_acknowledged';
-
-    public const LOGIN_DISAVOWED = 'spiriit.auth_log.login_disavowed';
 }

--- a/src/Confirmation/Exception/ConfirmationNotEnabledException.php
+++ b/src/Confirmation/Exception/ConfirmationNotEnabledException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Confirmation\Exception;
+
+final class ConfirmationNotEnabledException extends \RuntimeException
+{
+}

--- a/src/Controller/AuthenticationLogConfirmationController.php
+++ b/src/Controller/AuthenticationLogConfirmationController.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Controller;
+
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationAction;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogConfirmationEvent;
+use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogEvents;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+
+final readonly class AuthenticationLogConfirmationController
+{
+    public function __construct(
+        private UriSigner $uriSigner,
+        private ConfirmableAuthenticationLogRepositoryInterface $confirmableAuthenticationLogRepository,
+        private EventDispatcherInterface $eventDispatcher,
+        private Environment $twig,
+    ) {
+    }
+
+    public function __invoke(Request $request, ConfirmationAction $action, string $token): Response
+    {
+        if (!$this->uriSigner->checkRequest($request)) {
+            return $this->render('invalid', Response::HTTP_FORBIDDEN);
+        }
+
+        if ($this->isExpired($request)) {
+            return $this->render('expired', Response::HTTP_FORBIDDEN);
+        }
+
+        if (!$request->isMethod(Request::METHOD_POST)) {
+            return $this->renderConfirmationForm($action);
+        }
+
+        $authenticationLog = $this->confirmableAuthenticationLogRepository->findOneByConfirmationToken($token);
+
+        if (!$authenticationLog instanceof ConfirmableAuthenticationLogInterface || !$authenticationLog->isPending()) {
+            return $this->render('already_reviewed');
+        }
+
+        $this->review($authenticationLog, $action);
+
+        return $this->render(ConfirmationAction::ACKNOWLEDGE === $action ? 'acknowledged' : 'disavowed');
+    }
+
+    private function review(ConfirmableAuthenticationLogInterface $authenticationLog, ConfirmationAction $action): void
+    {
+        match ($action) {
+            ConfirmationAction::ACKNOWLEDGE => $authenticationLog->acknowledge(),
+            ConfirmationAction::DISAVOW => $authenticationLog->disavow(),
+        };
+
+        $this->confirmableAuthenticationLogRepository->save($authenticationLog);
+
+        $this->eventDispatcher->dispatch(
+            new AuthenticationLogConfirmationEvent($authenticationLog),
+            ConfirmationAction::ACKNOWLEDGE === $action
+                ? AuthenticationLogEvents::LOGIN_ACKNOWLEDGED
+                : AuthenticationLogEvents::LOGIN_DISAVOWED,
+        );
+    }
+
+    private function isExpired(Request $request): bool
+    {
+        $expires = $request->query->getInt('expires');
+
+        return 0 === $expires || $expires < time();
+    }
+
+    private function renderConfirmationForm(ConfirmationAction $action): Response
+    {
+        return new Response($this->twig->render('@SpiriitAuthLog/confirmation/show.html.twig', [
+            'action' => $action->value,
+        ]));
+    }
+
+    private function render(string $outcome, int $status = Response::HTTP_OK): Response
+    {
+        return new Response(
+            $this->twig->render('@SpiriitAuthLog/confirmation/result.html.twig', ['outcome' => $outcome]),
+            $status,
+        );
+    }
+}

--- a/src/Controller/AuthenticationLogConfirmationController.php
+++ b/src/Controller/AuthenticationLogConfirmationController.php
@@ -48,7 +48,11 @@ final readonly class AuthenticationLogConfirmationController
 
         $authenticationLog = $this->confirmableAuthenticationLogRepository->findOneByConfirmationToken($token);
 
-        if (null === $authenticationLog || !$authenticationLog->isPending()) {
+        if (null === $authenticationLog) {
+            return $this->render('not_found', Response::HTTP_NOT_FOUND);
+        }
+
+        if (!$authenticationLog->isPending()) {
             return $this->render('already_reviewed');
         }
 

--- a/src/Controller/AuthenticationLogConfirmationController.php
+++ b/src/Controller/AuthenticationLogConfirmationController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Spiriit\Bundle\AuthLogBundle\Controller;
 
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationAction;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogConfirmationEvent;
 use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogEvents;
@@ -48,7 +49,7 @@ final readonly class AuthenticationLogConfirmationController
 
         $authenticationLog = $this->confirmableAuthenticationLogRepository->findOneByConfirmationToken($token);
 
-        if (!$authenticationLog instanceof ConfirmableAuthenticationLogInterface || !$authenticationLog->isPending()) {
+        if (null === $authenticationLog || !$authenticationLog->isPending()) {
             return $this->render('already_reviewed');
         }
 
@@ -57,7 +58,7 @@ final readonly class AuthenticationLogConfirmationController
         return $this->render(ConfirmationAction::ACKNOWLEDGE === $action ? 'acknowledged' : 'disavowed');
     }
 
-    private function review(ConfirmableAuthenticationLogInterface $authenticationLog, ConfirmationAction $action): void
+    private function review(AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface $authenticationLog, ConfirmationAction $action): void
     {
         match ($action) {
             ConfirmationAction::ACKNOWLEDGE => $authenticationLog->acknowledge(),

--- a/src/Controller/AuthenticationLogConfirmationController.php
+++ b/src/Controller/AuthenticationLogConfirmationController.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Spiriit\Bundle\AuthLogBundle\Controller;
 
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationAction;
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogConfirmationEvent;
 use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogEvents;
@@ -58,7 +57,7 @@ final readonly class AuthenticationLogConfirmationController
         return $this->render(ConfirmationAction::ACKNOWLEDGE === $action ? 'acknowledged' : 'disavowed');
     }
 
-    private function review(AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface $authenticationLog, ConfirmationAction $action): void
+    private function review(ConfirmableAuthenticationLogInterface $authenticationLog, ConfirmationAction $action): void
     {
         match ($action) {
             ConfirmationAction::ACKNOWLEDGE => $authenticationLog->acknowledge(),

--- a/src/DependencyInjection/Compiler/RegisterTaggedImplementationsPass.php
+++ b/src/DependencyInjection/Compiler/RegisterTaggedImplementationsPass.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\DependencyInjection\Compiler;
+
+use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogCreatorInterface;
+use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Aliases each bundle interface to the consumer implementation that carries the
+ * matching tag, so a repository only has to implement the interfaces (the tags
+ * are applied by autoconfiguration) without declaring the aliases by hand.
+ */
+final class RegisterTaggedImplementationsPass implements CompilerPassInterface
+{
+    private const TAGGED_INTERFACES = [
+        'spiriit_auth_log.repository' => AuthenticationLogRepositoryInterface::class,
+        'spiriit_auth_log.creator' => AuthenticationLogCreatorInterface::class,
+        'spiriit_auth_log.confirmable_repository' => ConfirmableAuthenticationLogRepositoryInterface::class,
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (self::TAGGED_INTERFACES as $tag => $interface) {
+            $this->aliasTaggedImplementation($container, $tag, $interface);
+        }
+    }
+
+    private function aliasTaggedImplementation(ContainerBuilder $container, string $tag, string $interface): void
+    {
+        if ($container->has($interface)) {
+            return;
+        }
+
+        $serviceIds = array_keys($container->findTaggedServiceIds($tag));
+
+        if ([] === $serviceIds) {
+            return;
+        }
+
+        if (\count($serviceIds) > 1) {
+            throw new \LogicException(\sprintf('There are several services tagged "%s" (%s). Alias "%s" to the one to use instead.', $tag, implode(', ', $serviceIds), $interface));
+        }
+
+        $container->setAlias($interface, $serviceIds[0]);
+    }
+}

--- a/src/Entity/AbstractAuthenticationLog.php
+++ b/src/Entity/AbstractAuthenticationLog.php
@@ -17,7 +17,7 @@ use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\LocateUserInformation\Loca
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 
 #[ORM\MappedSuperclass]
-abstract class AbstractAuthenticationLog
+abstract class AbstractAuthenticationLog implements AuthenticationLogInterface
 {
     #[ORM\Column(type: Types::STRING, length: 45, nullable: true)]
     protected ?string $ipAddress;

--- a/src/Entity/AuthenticationLogInterface.php
+++ b/src/Entity/AuthenticationLogInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Entity;
+
+use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\LocateUserInformation\LocateValues;
+
+interface AuthenticationLogInterface
+{
+    public function getUser(): AuthLogUserInterface;
+
+    public function getIpAddress(): ?string;
+
+    public function getUserAgent(): ?string;
+
+    public function getLoginAt(): ?\DateTimeImmutable;
+
+    public function getLocation(): ?LocateValues;
+}

--- a/src/Entity/AuthenticationLogStatus.php
+++ b/src/Entity/AuthenticationLogStatus.php
@@ -9,13 +9,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Spiriit\Bundle\AuthLogBundle\Listener;
+namespace Spiriit\Bundle\AuthLogBundle\Entity;
 
-class AuthenticationLogEvents
+enum AuthenticationLogStatus: string
 {
-    public const NEW_DEVICE = 'spiriit.auth_log.new_device';
-
-    public const LOGIN_ACKNOWLEDGED = 'spiriit.auth_log.login_acknowledged';
-
-    public const LOGIN_DISAVOWED = 'spiriit.auth_log.login_disavowed';
+    case PENDING = 'pending';
+    case ACKNOWLEDGED = 'acknowledged';
+    case DISAVOWED = 'disavowed';
 }

--- a/src/Entity/ConfirmableAuthenticationLogInterface.php
+++ b/src/Entity/ConfirmableAuthenticationLogInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Entity;
+
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationToken;
+
+interface ConfirmableAuthenticationLogInterface
+{
+    public function enableConfirmation(ConfirmationToken $confirmationToken): void;
+
+    public function acknowledge(): void;
+
+    public function disavow(): void;
+
+    public function confirmationToken(): ?string;
+
+    public function status(): AuthenticationLogStatus;
+
+    public function respondedAt(): ?\DateTimeImmutable;
+
+    public function isPending(): bool;
+}

--- a/src/Entity/ConfirmableAuthenticationLogInterface.php
+++ b/src/Entity/ConfirmableAuthenticationLogInterface.php
@@ -13,7 +13,7 @@ namespace Spiriit\Bundle\AuthLogBundle\Entity;
 
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationToken;
 
-interface ConfirmableAuthenticationLogInterface
+interface ConfirmableAuthenticationLogInterface extends AuthenticationLogInterface
 {
     public function enableConfirmation(ConfirmationToken $confirmationToken): void;
 

--- a/src/Entity/ConfirmableAuthenticationLogTrait.php
+++ b/src/Entity/ConfirmableAuthenticationLogTrait.php
@@ -29,8 +29,11 @@ trait ConfirmableAuthenticationLogTrait
 
     public function enableConfirmation(ConfirmationToken $confirmationToken): void
     {
+        if (!$this->isPending()) {
+            throw new AuthenticationLogAlreadyReviewedException(\sprintf('Cannot enable confirmation on an authentication log that has already been reviewed as "%s".', $this->status->value));
+        }
+
         $this->confirmationToken = $confirmationToken->toString();
-        $this->status = AuthenticationLogStatus::PENDING;
     }
 
     public function acknowledge(): void

--- a/src/Entity/ConfirmableAuthenticationLogTrait.php
+++ b/src/Entity/ConfirmableAuthenticationLogTrait.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationToken;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\Exception\AuthenticationLogAlreadyReviewedException;
+
+trait ConfirmableAuthenticationLogTrait
+{
+    #[ORM\Column(type: Types::STRING, length: 100, unique: true, nullable: true)]
+    protected ?string $confirmationToken = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, enumType: AuthenticationLogStatus::class, options: ['default' => AuthenticationLogStatus::PENDING->value])]
+    protected AuthenticationLogStatus $status = AuthenticationLogStatus::PENDING;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    protected ?\DateTimeImmutable $respondedAt = null;
+
+    public function enableConfirmation(ConfirmationToken $confirmationToken): void
+    {
+        $this->confirmationToken = $confirmationToken->toString();
+        $this->status = AuthenticationLogStatus::PENDING;
+    }
+
+    public function acknowledge(): void
+    {
+        $this->review(AuthenticationLogStatus::ACKNOWLEDGED);
+    }
+
+    public function disavow(): void
+    {
+        $this->review(AuthenticationLogStatus::DISAVOWED);
+    }
+
+    public function confirmationToken(): ?string
+    {
+        return $this->confirmationToken;
+    }
+
+    public function status(): AuthenticationLogStatus
+    {
+        return $this->status;
+    }
+
+    public function respondedAt(): ?\DateTimeImmutable
+    {
+        return $this->respondedAt;
+    }
+
+    public function isPending(): bool
+    {
+        return AuthenticationLogStatus::PENDING === $this->status;
+    }
+
+    private function review(AuthenticationLogStatus $status): void
+    {
+        if (!$this->isPending()) {
+            throw new AuthenticationLogAlreadyReviewedException(\sprintf('Cannot review an authentication log that has already been reviewed as "%s".', $this->status->value));
+        }
+
+        $this->status = $status;
+        $this->respondedAt = new \DateTimeImmutable();
+    }
+}

--- a/src/Listener/AuthenticationLogConfirmationEvent.php
+++ b/src/Listener/AuthenticationLogConfirmationEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Listener;
+
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class AuthenticationLogConfirmationEvent extends Event
+{
+    public function __construct(
+        private readonly ConfirmableAuthenticationLogInterface $authenticationLog,
+    ) {
+    }
+
+    public function authenticationLog(): ConfirmableAuthenticationLogInterface
+    {
+        return $this->authenticationLog;
+    }
+}

--- a/src/Notification/MailerNotification.php
+++ b/src/Notification/MailerNotification.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\Notification;
 
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
 use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
@@ -30,7 +31,7 @@ final readonly class MailerNotification implements NotificationInterface
     ) {
     }
 
-    public function send(UserInformation $userInformation, UserReference $userReference): void
+    public function send(UserInformation $userInformation, UserReference $userReference, ?ConfirmationLinks $confirmationLinks = null): void
     {
         $templateEmail = (new TemplatedEmail())
             ->to(new Address(
@@ -44,6 +45,7 @@ final readonly class MailerNotification implements NotificationInterface
                 [
                     'userInformation' => $userInformation,
                     'authenticableLog' => $userReference,
+                    'confirmationLinks' => $confirmationLinks,
                 ],
             );
 

--- a/src/Notification/NewDeviceNotifier.php
+++ b/src/Notification/NewDeviceNotifier.php
@@ -14,7 +14,7 @@ namespace Spiriit\Bundle\AuthLogBundle\Notification;
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationUrlGenerator;
 use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 
@@ -26,12 +26,12 @@ final readonly class NewDeviceNotifier
     ) {
     }
 
-    public function notify(UserInformation $userInformation, UserReference $userReference, AbstractAuthenticationLog $authenticationLog): void
+    public function notify(UserInformation $userInformation, UserReference $userReference, AuthenticationLogInterface $authenticationLog): void
     {
         $this->notification->send($userInformation, $userReference, $this->confirmationLinks($authenticationLog));
     }
 
-    private function confirmationLinks(AbstractAuthenticationLog $authenticationLog): ?ConfirmationLinks
+    private function confirmationLinks(AuthenticationLogInterface $authenticationLog): ?ConfirmationLinks
     {
         if (null === $this->confirmationUrlGenerator) {
             return null;

--- a/src/Notification/NewDeviceNotifier.php
+++ b/src/Notification/NewDeviceNotifier.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Notification;
+
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationUrlGenerator;
+use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
+
+final readonly class NewDeviceNotifier
+{
+    public function __construct(
+        private NotificationInterface $notification,
+        private ?ConfirmationUrlGenerator $confirmationUrlGenerator = null,
+    ) {
+    }
+
+    public function notify(UserInformation $userInformation, UserReference $userReference, AbstractAuthenticationLog $authenticationLog): void
+    {
+        $this->notification->send($userInformation, $userReference, $this->confirmationLinks($authenticationLog));
+    }
+
+    private function confirmationLinks(AbstractAuthenticationLog $authenticationLog): ?ConfirmationLinks
+    {
+        if (null === $this->confirmationUrlGenerator) {
+            return null;
+        }
+
+        if (!$authenticationLog instanceof ConfirmableAuthenticationLogInterface || null === $authenticationLog->confirmationToken()) {
+            return null;
+        }
+
+        return $this->confirmationUrlGenerator->generate($authenticationLog);
+    }
+}

--- a/src/Notification/NotificationInterface.php
+++ b/src/Notification/NotificationInterface.php
@@ -11,10 +11,11 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\Notification;
 
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
 use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 
 interface NotificationInterface
 {
-    public function send(UserInformation $userInformation, UserReference $userReference): void;
+    public function send(UserInformation $userInformation, UserReference $userReference, ?ConfirmationLinks $confirmationLinks = null): void;
 }

--- a/src/Repository/AuthenticationLogRepositoryInterface.php
+++ b/src/Repository/AuthenticationLogRepositoryInterface.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\Repository;
 
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 
 interface AuthenticationLogRepositoryInterface
 {
-    public function save(AbstractAuthenticationLog $log): void;
+    public function save(AuthenticationLogInterface $log): void;
 
     public function findExistingLog(string $userIdentifier, UserInformation $userInformation): bool;
 }

--- a/src/Repository/ConfirmableAuthenticationLogRepositoryInterface.php
+++ b/src/Repository/ConfirmableAuthenticationLogRepositoryInterface.php
@@ -11,10 +11,9 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\Repository;
 
-use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 
 interface ConfirmableAuthenticationLogRepositoryInterface extends AuthenticationLogRepositoryInterface
 {
-    public function findOneByConfirmationToken(string $confirmationToken): (AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface)|null;
+    public function findOneByConfirmationToken(string $confirmationToken): ?ConfirmableAuthenticationLogInterface;
 }

--- a/src/Repository/ConfirmableAuthenticationLogRepositoryInterface.php
+++ b/src/Repository/ConfirmableAuthenticationLogRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\AuthLogBundle\Repository;
+
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+
+interface ConfirmableAuthenticationLogRepositoryInterface
+{
+    public function findOneByConfirmationToken(string $confirmationToken): ?ConfirmableAuthenticationLogInterface;
+
+    public function save(ConfirmableAuthenticationLogInterface $authenticationLog): void;
+}

--- a/src/Repository/ConfirmableAuthenticationLogRepositoryInterface.php
+++ b/src/Repository/ConfirmableAuthenticationLogRepositoryInterface.php
@@ -11,11 +11,10 @@ declare(strict_types=1);
 
 namespace Spiriit\Bundle\AuthLogBundle\Repository;
 
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 
-interface ConfirmableAuthenticationLogRepositoryInterface
+interface ConfirmableAuthenticationLogRepositoryInterface extends AuthenticationLogRepositoryInterface
 {
-    public function findOneByConfirmationToken(string $confirmationToken): ?ConfirmableAuthenticationLogInterface;
-
-    public function save(ConfirmableAuthenticationLogInterface $authenticationLog): void;
+    public function findOneByConfirmationToken(string $confirmationToken): (AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface)|null;
 }

--- a/src/Services/LoginService.php
+++ b/src/Services/LoginService.php
@@ -17,7 +17,7 @@ use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\FetchUserInformation;
 use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogEvent;
 use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogEvents;
-use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
+use Spiriit\Bundle\AuthLogBundle\Notification\NewDeviceNotifier;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class LoginService
@@ -25,7 +25,7 @@ final class LoginService
     public function __construct(
         private readonly FetchUserInformation $fetchUserInformation,
         private readonly AuthenticationLogHandlerInterface $handler,
-        private readonly NotificationInterface $notifier,
+        private readonly NewDeviceNotifier $newDeviceNotifier,
         private readonly EventDispatcherInterface $dispatcher,
     ) {
     }
@@ -38,7 +38,7 @@ final class LoginService
             return;
         }
 
-        $this->handler->handle($dto->userIdentifier, $userInformation);
+        $log = $this->handler->handle($dto->userIdentifier, $userInformation);
 
         $this->dispatcher->dispatch(
             new AuthenticationLogEvent($dto->userIdentifier, $userInformation),
@@ -50,6 +50,6 @@ final class LoginService
             email: $dto->toEmail,
             displayName: $dto->toEmailName,
         );
-        $this->notifier->send($userInformation, $userReference);
+        $this->newDeviceNotifier->notify($userInformation, $userReference, $log);
     }
 }

--- a/src/SpiriitAuthLogBundle.php
+++ b/src/SpiriitAuthLogBundle.php
@@ -106,6 +106,18 @@ final class SpiriitAuthLogBundle extends AbstractBundle
                         ->scalarNode('token_ttl')
                             ->defaultValue('3 days')
                             ->cannotBeEmpty()
+                            ->validate()
+                                ->ifTrue(static function ($tokenTtl): bool {
+                                    try {
+                                        new \DateTimeImmutable('+'.$tokenTtl);
+
+                                        return false;
+                                    } catch (\Throwable) {
+                                        return true;
+                                    }
+                                })
+                                ->thenInvalid('Invalid confirmation "token_ttl" value %s: it must be a relative date expression such as "3 days" or "12 hours".')
+                            ->end()
                             ->info('Lifetime of a confirmation link, as a relative date expression (e.g. "3 days", "12 hours").')
                         ->end()
                         ->scalarNode('route_name')

--- a/src/SpiriitAuthLogBundle.php
+++ b/src/SpiriitAuthLogBundle.php
@@ -21,6 +21,7 @@ use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\LocateUserInformation\IpAp
 use Spiriit\Bundle\AuthLogBundle\Notification\MailerNotification;
 use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
 use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -40,6 +41,8 @@ final class SpiriitAuthLogBundle extends AbstractBundle
             ->addTag('spiriit_auth_log.creator');
         $container->registerForAutoconfiguration(AuthenticationLogHandlerInterface::class)
             ->addTag('spiriit_auth_log.handler');
+        $container->registerForAutoconfiguration(ConfirmableAuthenticationLogRepositoryInterface::class)
+            ->addTag('spiriit_auth_log.confirmable_repository');
     }
 
     public function configure(DefinitionConfigurator $definition): void
@@ -88,6 +91,25 @@ final class SpiriitAuthLogBundle extends AbstractBundle
                             return null !== $v && ($v['provider'] ?? null) === 'geoip2' && empty($v['geoip2_database_path']);
                         })
                         ->thenInvalid('The "geoip2_database_path" field is required when using the "geoip2" provider.')
+                    ->end()
+                ->end()
+                ->arrayNode('confirmation')
+                    ->addDefaultsIfNotSet()
+                    ->info('Enables the "It was me / It wasn\'t me" signed confirmation links in the notification email.')
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('token_ttl')
+                            ->defaultValue('3 days')
+                            ->cannotBeEmpty()
+                            ->info('Lifetime of a confirmation link, as a relative date expression (e.g. "3 days", "12 hours").')
+                        ->end()
+                        ->scalarNode('route_name')
+                            ->defaultValue('spiriit_auth_log_confirm')
+                            ->cannotBeEmpty()
+                            ->info('Name of the route pointing to the confirmation controller. Override it if you declare your own route instead of importing the bundle one.')
+                        ->end()
                     ->end()
                 ->end()
             ->end()
@@ -150,6 +172,20 @@ final class SpiriitAuthLogBundle extends AbstractBundle
 
         // Event dispatcher alias
         $builder->setAlias('spiriit_auth_log.login_event_dispatcher', 'event_dispatcher');
+
+        // Confirmation ("It was me / It wasn't me" signed links)
+        if ($config['confirmation']['enabled']) {
+            $builder->setParameter('spiriit_auth_log.confirmation.token_ttl', $config['confirmation']['token_ttl']);
+            $builder->setParameter('spiriit_auth_log.confirmation.route_name', $config['confirmation']['route_name']);
+
+            $container->import('../config/confirmation.php');
+
+            $builder->getDefinition('spiriit_auth_log.handler')
+                ->setArgument('$confirmationTokenGenerator', new Reference('spiriit_auth_log.confirmation_token_generator'));
+
+            $builder->getDefinition('spiriit_auth_log.new_device_notifier')
+                ->setArgument('$confirmationUrlGenerator', new Reference('spiriit_auth_log.confirmation_url_generator'));
+        }
 
         // Messenger (async)
         if ($config['messenger']) {

--- a/src/SpiriitAuthLogBundle.php
+++ b/src/SpiriitAuthLogBundle.php
@@ -14,6 +14,7 @@ namespace Spiriit\Bundle\AuthLogBundle;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogCreatorInterface;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogHandlerInterface;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\DoctrineAuthenticationLogHandler;
+use Spiriit\Bundle\AuthLogBundle\DependencyInjection\Compiler\RegisterTaggedImplementationsPass;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\FetchUserInformation;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\FetchUserInformationMethodInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\LocateUserInformation\Geoip2LocateMethod;
@@ -43,6 +44,8 @@ final class SpiriitAuthLogBundle extends AbstractBundle
             ->addTag('spiriit_auth_log.handler');
         $container->registerForAutoconfiguration(ConfirmableAuthenticationLogRepositoryInterface::class)
             ->addTag('spiriit_auth_log.confirmable_repository');
+
+        $container->addCompilerPass(new RegisterTaggedImplementationsPass());
     }
 
     public function configure(DefinitionConfigurator $definition): void

--- a/templates/confirmation/result.html.twig
+++ b/templates/confirmation/result.html.twig
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="{{ app.request.locale|default('en') }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ ('confirmation.result.' ~ outcome ~ '.title')|trans({}, 'SpiriitAuthLogBundle') }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f6f6f6;
+            margin: 0;
+            padding: 20px;
+        }
+        .container {
+            max-width: 600px;
+            margin: 40px auto;
+            background: #ffffff;
+            border-radius: 8px;
+            padding: 30px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+            text-align: center;
+        }
+        h1 {
+            font-size: 20px;
+            margin-bottom: 15px;
+            color: #333;
+        }
+        p {
+            font-size: 14px;
+            color: #555;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>{{ ('confirmation.result.' ~ outcome ~ '.title')|trans({}, 'SpiriitAuthLogBundle') }}</h1>
+    <p>{{ ('confirmation.result.' ~ outcome ~ '.message')|trans({}, 'SpiriitAuthLogBundle') }}</p>
+</div>
+</body>
+</html>

--- a/templates/confirmation/show.html.twig
+++ b/templates/confirmation/show.html.twig
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="{{ app.request.locale|default('en') }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ ('confirmation.show.' ~ action ~ '.title')|trans({}, 'SpiriitAuthLogBundle') }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f6f6f6;
+            margin: 0;
+            padding: 20px;
+        }
+        .container {
+            max-width: 600px;
+            margin: 40px auto;
+            background: #ffffff;
+            border-radius: 8px;
+            padding: 30px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+            text-align: center;
+        }
+        h1 {
+            font-size: 20px;
+            margin-bottom: 15px;
+            color: #333;
+        }
+        p {
+            font-size: 14px;
+            color: #555;
+            line-height: 1.6;
+        }
+        button {
+            margin-top: 20px;
+            padding: 12px 24px;
+            border: none;
+            border-radius: 5px;
+            font-size: 15px;
+            font-weight: bold;
+            color: #ffffff;
+            cursor: pointer;
+        }
+        button.acknowledge {
+            background: #2e7d32;
+        }
+        button.disavow {
+            background: #c62828;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>{{ ('confirmation.show.' ~ action ~ '.title')|trans({}, 'SpiriitAuthLogBundle') }}</h1>
+    <p>{{ ('confirmation.show.' ~ action ~ '.message')|trans({}, 'SpiriitAuthLogBundle') }}</p>
+    <form method="post" action="{{ app.request.requestUri }}">
+        <button type="submit" class="{{ action }}">{{ ('confirmation.show.' ~ action ~ '.button')|trans({}, 'SpiriitAuthLogBundle') }}</button>
+    </form>
+</div>
+</body>
+</html>

--- a/templates/new_device.html.twig
+++ b/templates/new_device.html.twig
@@ -44,6 +44,27 @@
             margin-top: 20px;
             text-align: center;
         }
+        .actions {
+            margin: 20px 0;
+            text-align: center;
+        }
+        .actions a {
+            display: inline-block;
+            padding: 10px 18px;
+            margin: 5px;
+            border-radius: 5px;
+            font-size: 14px;
+            font-weight: bold;
+            text-decoration: none;
+        }
+        .actions .acknowledge {
+            background: #2e7d32;
+            color: #ffffff;
+        }
+        .actions .disavow {
+            background: #c62828;
+            color: #ffffff;
+        }
     </style>
 </head>
 <body>
@@ -72,6 +93,13 @@
     </div>
 
     <p>Si vous n’êtes pas à l’origine de cette connexion, nous vous conseillons de changer votre mot de passe immédiatement.</p>
+
+    {% if confirmationLinks is defined and confirmationLinks is not null %}
+        <div class="actions">
+            <a class="acknowledge" href="{{ confirmationLinks.acknowledgeUrl }}">{{ 'confirmation.email.acknowledge'|trans({}, 'SpiriitAuthLogBundle') }}</a>
+            <a class="disavow" href="{{ confirmationLinks.disavowUrl }}">{{ 'confirmation.email.disavow'|trans({}, 'SpiriitAuthLogBundle') }}</a>
+        </div>
+    {% endif %}
 
     <div class="footer">
         <p>Ceci est un message automatique, merci de ne pas répondre directement à cet e-mail.</p>

--- a/tests/AuthenticationLog/DoctrineAuthenticationLogHandlerTest.php
+++ b/tests/AuthenticationLog/DoctrineAuthenticationLogHandlerTest.php
@@ -14,7 +14,11 @@ namespace Spiriit\Bundle\Tests\AuthenticationLog;
 use PHPUnit\Framework\TestCase;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogCreatorInterface;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\DoctrineAuthenticationLogHandler;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationTokenGenerator;
 use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthLogUserInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogTrait;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
 
@@ -58,5 +62,29 @@ final class DoctrineAuthenticationLogHandlerTest extends TestCase
 
         $handler = new DoctrineAuthenticationLogHandler($repository, $creator);
         $handler->handle('user-1', $userInformation);
+    }
+
+    public function testItShouldEnableConfirmationWhenGeneratorIsProvidedAndLogIsConfirmable(): void
+    {
+        $userInformation = new UserInformation('127.0.0.1', 'PHPUnit', new \DateTimeImmutable(), null);
+        $log = new class($userInformation) extends AbstractAuthenticationLog implements ConfirmableAuthenticationLogInterface {
+            use ConfirmableAuthenticationLogTrait;
+
+            public function getUser(): AuthLogUserInterface
+            {
+                throw new \RuntimeException('Stub');
+            }
+        };
+
+        $repository = $this->createStub(AuthenticationLogRepositoryInterface::class);
+        $creator = $this->createStub(AuthenticationLogCreatorInterface::class);
+        $creator->method('createLog')->willReturn($log);
+
+        $handler = new DoctrineAuthenticationLogHandler($repository, $creator, new ConfirmationTokenGenerator());
+        $result = $handler->handle('user-1', $userInformation);
+
+        self::assertSame($log, $result);
+        self::assertNotNull($log->confirmationToken());
+        self::assertTrue($log->isPending());
     }
 }

--- a/tests/Confirmation/ConfirmationTokenGeneratorTest.php
+++ b/tests/Confirmation/ConfirmationTokenGeneratorTest.php
@@ -27,6 +27,15 @@ final class ConfirmationTokenGeneratorTest extends TestCase
         self::assertSame(32, \strlen($token->toString()));
     }
 
+    public function testItShouldGenerateAUrlSafeToken(): void
+    {
+        $confirmationTokenGenerator = new ConfirmationTokenGenerator();
+
+        $token = $confirmationTokenGenerator->generate()->toString();
+
+        self::assertMatchesRegularExpression('/^[A-Za-z0-9]+$/', $token);
+    }
+
     public function testItShouldGenerateUniqueTokens(): void
     {
         $confirmationTokenGenerator = new ConfirmationTokenGenerator();

--- a/tests/Confirmation/ConfirmationTokenGeneratorTest.php
+++ b/tests/Confirmation/ConfirmationTokenGeneratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\Tests\Confirmation;
+
+use PHPUnit\Framework\TestCase;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationToken;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationTokenGenerator;
+
+final class ConfirmationTokenGeneratorTest extends TestCase
+{
+    public function testItShouldGenerateAToken(): void
+    {
+        $confirmationTokenGenerator = new ConfirmationTokenGenerator();
+
+        $token = $confirmationTokenGenerator->generate();
+
+        self::assertInstanceOf(ConfirmationToken::class, $token);
+        self::assertSame(32, \strlen($token->toString()));
+    }
+
+    public function testItShouldGenerateUniqueTokens(): void
+    {
+        $confirmationTokenGenerator = new ConfirmationTokenGenerator();
+
+        self::assertNotSame(
+            $confirmationTokenGenerator->generate()->toString(),
+            $confirmationTokenGenerator->generate()->toString(),
+        );
+    }
+}

--- a/tests/Confirmation/ConfirmationUrlGeneratorTest.php
+++ b/tests/Confirmation/ConfirmationUrlGeneratorTest.php
@@ -13,6 +13,7 @@ namespace Spiriit\Bundle\Tests\Confirmation;
 
 use PHPUnit\Framework\TestCase;
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationUrlGenerator;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\Exception\ConfirmationNotEnabledException;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -40,5 +41,20 @@ final class ConfirmationUrlGeneratorTest extends TestCase
         self::assertTrue($uriSigner->check($links->disavowUrl));
         self::assertStringContainsString('acknowledge', $links->acknowledgeUrl);
         self::assertStringContainsString('disavow', $links->disavowUrl);
+    }
+
+    public function testItShouldThrowWhenConfirmationIsNotEnabled(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::never())->method('generate');
+
+        $log = $this->createStub(ConfirmableAuthenticationLogInterface::class);
+        $log->method('confirmationToken')->willReturn(null);
+
+        $confirmationUrlGenerator = new ConfirmationUrlGenerator($urlGenerator, new UriSigner('a-secret'), 'spiriit_auth_log_confirm', '3 days');
+
+        $this->expectException(ConfirmationNotEnabledException::class);
+
+        $confirmationUrlGenerator->generate($log);
     }
 }

--- a/tests/Confirmation/ConfirmationUrlGeneratorTest.php
+++ b/tests/Confirmation/ConfirmationUrlGeneratorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\Tests\Confirmation;
+
+use PHPUnit\Framework\TestCase;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationUrlGenerator;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class ConfirmationUrlGeneratorTest extends TestCase
+{
+    public function testItShouldGenerateTwoSignedLinks(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturnCallback(
+            static fn (string $name, array $parameters = []): string => 'https://app.test/auth-log/confirm/'.$parameters['action'].'/'.$parameters['token'].'?expires='.$parameters['expires']
+        );
+
+        $uriSigner = new UriSigner('a-secret');
+
+        $log = $this->createStub(ConfirmableAuthenticationLogInterface::class);
+        $log->method('confirmationToken')->willReturn('the-token');
+
+        $confirmationUrlGenerator = new ConfirmationUrlGenerator($urlGenerator, $uriSigner, 'spiriit_auth_log_confirm', '3 days');
+
+        $links = $confirmationUrlGenerator->generate($log);
+
+        self::assertNotSame($links->acknowledgeUrl, $links->disavowUrl);
+        self::assertTrue($uriSigner->check($links->acknowledgeUrl));
+        self::assertTrue($uriSigner->check($links->disavowUrl));
+        self::assertStringContainsString('acknowledge', $links->acknowledgeUrl);
+        self::assertStringContainsString('disavow', $links->disavowUrl);
+    }
+}

--- a/tests/Controller/AuthenticationLogConfirmationControllerTest.php
+++ b/tests/Controller/AuthenticationLogConfirmationControllerTest.php
@@ -139,6 +139,18 @@ final class AuthenticationLogConfirmationControllerTest extends TestCase
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
+    public function testItShouldReportNotFoundWhenTokenMatchesNoLog(): void
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::never())->method('dispatch');
+
+        $controller = $this->controller($this->repository($this->pendingLog()), $dispatcher, $this->twigExpecting('result', 'not_found'));
+
+        $response = $controller($this->signedRequest('acknowledge', 'unknown-token', 'POST'), ConfirmationAction::ACKNOWLEDGE, 'unknown-token');
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
     private function controller(ConfirmableAuthenticationLogRepositoryInterface $repository, EventDispatcherInterface $dispatcher, Environment $twig): AuthenticationLogConfirmationController
     {
         return new AuthenticationLogConfirmationController(

--- a/tests/Controller/AuthenticationLogConfirmationControllerTest.php
+++ b/tests/Controller/AuthenticationLogConfirmationControllerTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\Tests\Controller;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationAction;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationToken;
+use Spiriit\Bundle\AuthLogBundle\Controller\AuthenticationLogConfirmationController;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogStatus;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthLogUserInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogTrait;
+use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
+use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogConfirmationEvent;
+use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogEvents;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+
+final class AuthenticationLogConfirmationControllerTest extends TestCase
+{
+    private const SECRET = 'a-secret';
+
+    public function testItShouldAcknowledgeOnValidPost(): void
+    {
+        $log = $this->pendingLog();
+        $repository = $this->repository($log);
+        $repository->expects(self::once())->method('save')->with($log);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::once())
+            ->method('dispatch')
+            ->with(self::isInstanceOf(AuthenticationLogConfirmationEvent::class), AuthenticationLogEvents::LOGIN_ACKNOWLEDGED)
+            ->willReturnArgument(0);
+
+        $controller = $this->controller($repository, $dispatcher, $this->twigExpecting('result', 'acknowledged'));
+
+        $response = $controller(
+            $this->signedRequest('acknowledge', 'the-token', 'POST'),
+            ConfirmationAction::ACKNOWLEDGE,
+            'the-token',
+        );
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame(AuthenticationLogStatus::ACKNOWLEDGED, $log->status());
+    }
+
+    public function testItShouldDisavowOnValidPost(): void
+    {
+        $log = $this->pendingLog();
+        $repository = $this->repository($log);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::once())
+            ->method('dispatch')
+            ->with(self::isInstanceOf(AuthenticationLogConfirmationEvent::class), AuthenticationLogEvents::LOGIN_DISAVOWED)
+            ->willReturnArgument(0);
+
+        $controller = $this->controller($repository, $dispatcher, $this->twigExpecting('result', 'disavowed'));
+
+        $controller($this->signedRequest('disavow', 'the-token', 'POST'), ConfirmationAction::DISAVOW, 'the-token');
+
+        self::assertSame(AuthenticationLogStatus::DISAVOWED, $log->status());
+    }
+
+    public function testItShouldShowTheConfirmationFormOnGet(): void
+    {
+        $log = $this->pendingLog();
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::never())->method('dispatch');
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::once())
+            ->method('render')
+            ->with('@SpiriitAuthLog/confirmation/show.html.twig', self::anything())
+            ->willReturn('form');
+
+        $controller = $this->controller($this->repository($log), $dispatcher, $twig);
+
+        $response = $controller($this->signedRequest('acknowledge', 'the-token', 'GET'), ConfirmationAction::ACKNOWLEDGE, 'the-token');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertTrue($log->isPending());
+    }
+
+    public function testItShouldRejectATamperedSignature(): void
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::never())->method('dispatch');
+
+        $controller = $this->controller($this->repository($this->pendingLog()), $dispatcher, $this->twigExpecting('result', 'invalid'));
+
+        $request = Request::create('https://app.test/auth-log/confirm/acknowledge/the-token?expires='.(time() + 3600), 'GET');
+
+        $response = $controller($request, ConfirmationAction::ACKNOWLEDGE, 'the-token');
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function testItShouldRejectAnExpiredLink(): void
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::never())->method('dispatch');
+
+        $controller = $this->controller($this->repository($this->pendingLog()), $dispatcher, $this->twigExpecting('result', 'expired'));
+
+        $response = $controller($this->signedRequest('acknowledge', 'the-token', 'GET', time() - 3600), ConfirmationAction::ACKNOWLEDGE, 'the-token');
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function testItShouldReportAnAlreadyReviewedLog(): void
+    {
+        $log = $this->pendingLog();
+        $log->acknowledge();
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::never())->method('dispatch');
+
+        $controller = $this->controller($this->repository($log), $dispatcher, $this->twigExpecting('result', 'already_reviewed'));
+
+        $response = $controller($this->signedRequest('acknowledge', 'the-token', 'POST'), ConfirmationAction::ACKNOWLEDGE, 'the-token');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    private function controller(ConfirmableAuthenticationLogRepositoryInterface $repository, EventDispatcherInterface $dispatcher, Environment $twig): AuthenticationLogConfirmationController
+    {
+        return new AuthenticationLogConfirmationController(
+            new UriSigner(self::SECRET),
+            $repository,
+            $dispatcher,
+            $twig,
+        );
+    }
+
+    private function signedRequest(string $action, string $token, string $method, ?int $expires = null): Request
+    {
+        $uriSigner = new UriSigner(self::SECRET);
+        $url = \sprintf('https://app.test/auth-log/confirm/%s/%s?expires=%d', $action, $token, $expires ?? time() + 3600);
+
+        return Request::create($uriSigner->sign($url), $method);
+    }
+
+    private function twigExpecting(string $template, string $outcome): Environment
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')
+            ->with(
+                '@SpiriitAuthLog/confirmation/'.$template.'.html.twig',
+                self::callback(static fn (array $context): bool => ($context['outcome'] ?? null) === $outcome),
+            )
+            ->willReturn('rendered');
+
+        return $twig;
+    }
+
+    /**
+     * @return ConfirmableAuthenticationLogRepositoryInterface&MockObject
+     */
+    private function repository(ConfirmableAuthenticationLogInterface $log): ConfirmableAuthenticationLogRepositoryInterface
+    {
+        $repository = $this->createMock(ConfirmableAuthenticationLogRepositoryInterface::class);
+        $repository->method('findOneByConfirmationToken')
+            ->willReturnCallback(static fn (string $token): ?ConfirmableAuthenticationLogInterface => 'the-token' === $token ? $log : null);
+
+        return $repository;
+    }
+
+    private function pendingLog(): ConfirmableAuthenticationLogInterface&AbstractAuthenticationLog
+    {
+        $log = new class(new UserInformation('127.0.0.1', 'PHPUnit', new \DateTimeImmutable(), null)) extends AbstractAuthenticationLog implements ConfirmableAuthenticationLogInterface {
+            use ConfirmableAuthenticationLogTrait;
+
+            public function getUser(): AuthLogUserInterface
+            {
+                throw new \RuntimeException('Stub');
+            }
+        };
+        $log->enableConfirmation(new ConfirmationToken('the-token'));
+
+        return $log;
+    }
+}

--- a/tests/DependencyInjection/Compiler/RegisterTaggedImplementationsPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterTaggedImplementationsPassTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Spiriit\Bundle\AuthLogBundle\DependencyInjection\Compiler\RegisterTaggedImplementationsPass;
+use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterTaggedImplementationsPassTest extends TestCase
+{
+    public function testItShouldAliasInterfaceToTaggedImplementation(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('app.auth_log_repository', \stdClass::class)
+            ->addTag('spiriit_auth_log.confirmable_repository');
+
+        (new RegisterTaggedImplementationsPass())->process($container);
+
+        self::assertTrue($container->hasAlias(ConfirmableAuthenticationLogRepositoryInterface::class));
+        self::assertSame('app.auth_log_repository', (string) $container->getAlias(ConfirmableAuthenticationLogRepositoryInterface::class));
+    }
+
+    public function testItShouldNotOverrideAnExistingWiring(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('app.tagged_repository', \stdClass::class)
+            ->addTag('spiriit_auth_log.repository');
+        $container->register(AuthenticationLogRepositoryInterface::class, \stdClass::class);
+
+        (new RegisterTaggedImplementationsPass())->process($container);
+
+        self::assertFalse($container->hasAlias(AuthenticationLogRepositoryInterface::class));
+        self::assertTrue($container->hasDefinition(AuthenticationLogRepositoryInterface::class));
+    }
+
+    public function testItShouldFailWhenSeveralServicesAreTagged(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('app.repository_one', \stdClass::class)
+            ->addTag('spiriit_auth_log.repository');
+        $container->register('app.repository_two', \stdClass::class)
+            ->addTag('spiriit_auth_log.repository');
+
+        self::expectException(\LogicException::class);
+
+        (new RegisterTaggedImplementationsPass())->process($container);
+    }
+
+    public function testItShouldDoNothingWhenNoServiceIsTagged(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new RegisterTaggedImplementationsPass())->process($container);
+
+        self::assertFalse($container->has(ConfirmableAuthenticationLogRepositoryInterface::class));
+    }
+}

--- a/tests/DependencyInjection/SpiriitAuthLogExtensionTest.php
+++ b/tests/DependencyInjection/SpiriitAuthLogExtensionTest.php
@@ -47,4 +47,12 @@ class SpiriitAuthLogExtensionTest extends KernelTestCase
 
         self::bootKernel(['config' => 'empty']);
     }
+
+    public function testItShouldFailWhenTokenTtlIsNotARelativeDateExpression(): void
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('Invalid confirmation "token_ttl" value "not-a-duration"');
+
+        self::bootKernel(['config' => 'invalid_ttl']);
+    }
 }

--- a/tests/Entity/ConfirmableAuthenticationLogTraitTest.php
+++ b/tests/Entity/ConfirmableAuthenticationLogTraitTest.php
@@ -70,6 +70,17 @@ final class ConfirmableAuthenticationLogTraitTest extends TestCase
         $log->disavow();
     }
 
+    public function testItShouldRejectEnablingConfirmationOnAnAlreadyReviewedLog(): void
+    {
+        $log = $this->createConfirmableLog();
+        $log->enableConfirmation(new ConfirmationToken('the-token'));
+        $log->acknowledge();
+
+        self::expectException(AuthenticationLogAlreadyReviewedException::class);
+
+        $log->enableConfirmation(new ConfirmationToken('another-token'));
+    }
+
     private function createConfirmableLog(): ConfirmableAuthenticationLogInterface&AbstractAuthenticationLog
     {
         $userInformation = new UserInformation('127.0.0.1', 'PHPUnit', new \DateTimeImmutable(), null);

--- a/tests/Entity/ConfirmableAuthenticationLogTraitTest.php
+++ b/tests/Entity/ConfirmableAuthenticationLogTraitTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationToken;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\Exception\AuthenticationLogAlreadyReviewedException;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogStatus;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthLogUserInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogTrait;
+use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
+
+final class ConfirmableAuthenticationLogTraitTest extends TestCase
+{
+    public function testItShouldBePendingOnceConfirmationIsEnabled(): void
+    {
+        $log = $this->createConfirmableLog();
+
+        $log->enableConfirmation(new ConfirmationToken('the-token'));
+
+        self::assertTrue($log->isPending());
+        self::assertSame('the-token', $log->confirmationToken());
+        self::assertSame(AuthenticationLogStatus::PENDING, $log->status());
+        self::assertNull($log->respondedAt());
+    }
+
+    public function testItShouldAcknowledgeAPendingLog(): void
+    {
+        $log = $this->createConfirmableLog();
+        $log->enableConfirmation(new ConfirmationToken('the-token'));
+
+        $log->acknowledge();
+
+        self::assertSame(AuthenticationLogStatus::ACKNOWLEDGED, $log->status());
+        self::assertFalse($log->isPending());
+        self::assertNotNull($log->respondedAt());
+    }
+
+    public function testItShouldDisavowAPendingLog(): void
+    {
+        $log = $this->createConfirmableLog();
+        $log->enableConfirmation(new ConfirmationToken('the-token'));
+
+        $log->disavow();
+
+        self::assertSame(AuthenticationLogStatus::DISAVOWED, $log->status());
+        self::assertFalse($log->isPending());
+        self::assertNotNull($log->respondedAt());
+    }
+
+    public function testItShouldRejectReviewingAnAlreadyReviewedLog(): void
+    {
+        $log = $this->createConfirmableLog();
+        $log->enableConfirmation(new ConfirmationToken('the-token'));
+        $log->acknowledge();
+
+        self::expectException(AuthenticationLogAlreadyReviewedException::class);
+
+        $log->disavow();
+    }
+
+    private function createConfirmableLog(): ConfirmableAuthenticationLogInterface&AbstractAuthenticationLog
+    {
+        $userInformation = new UserInformation('127.0.0.1', 'PHPUnit', new \DateTimeImmutable(), null);
+
+        return new class($userInformation) extends AbstractAuthenticationLog implements ConfirmableAuthenticationLogInterface {
+            use ConfirmableAuthenticationLogTrait;
+
+            public function getUser(): AuthLogUserInterface
+            {
+                throw new \RuntimeException('Stub');
+            }
+        };
+    }
+}

--- a/tests/Integration/ContainerLintTest.php
+++ b/tests/Integration/ContainerLintTest.php
@@ -194,6 +194,35 @@ class ContainerLintTest extends KernelTestCase
     }
 
     /**
+     * When confirmation is enabled, the token generator, URL generator and
+     * confirmation controller must all be registered and instantiable.
+     */
+    public function testConfirmationServicesAreInstantiableWhenEnabled(): void
+    {
+        self::bootKernel(['config' => 'confirmation']);
+        $container = self::getContainer();
+
+        foreach (['spiriit_auth_log.confirmation_token_generator', 'spiriit_auth_log.confirmation_url_generator', 'spiriit_auth_log.confirmation_controller'] as $id) {
+            self::assertTrue($container->has($id), \sprintf('Service "%s" should be registered', $id));
+            $container->get($id);
+        }
+    }
+
+    /**
+     * When confirmation is disabled (default), none of its services must leak
+     * into the container.
+     */
+    public function testConfirmationServicesAreAbsentWhenDisabled(): void
+    {
+        self::bootKernel(['config' => 'minimal']);
+        $container = self::getContainer();
+
+        self::assertFalse($container->has('spiriit_auth_log.confirmation_token_generator'));
+        self::assertFalse($container->has('spiriit_auth_log.confirmation_url_generator'));
+        self::assertFalse($container->has('spiriit_auth_log.confirmation_controller'));
+    }
+
+    /**
      * @return iterable<string, array{string}>
      */
     public static function configProvider(): iterable

--- a/tests/Integration/Stubs/BundleExtension.php
+++ b/tests/Integration/Stubs/BundleExtension.php
@@ -13,6 +13,7 @@ use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogCreatorInter
 use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
 use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
 use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
@@ -50,7 +51,7 @@ class BundleExtension extends Extension
  */
 class StubAuthenticationLogRepository implements AuthenticationLogRepositoryInterface, ConfirmableAuthenticationLogRepositoryInterface
 {
-    public function save(AbstractAuthenticationLog $log): void
+    public function save(AuthenticationLogInterface $log): void
     {
     }
 
@@ -59,7 +60,7 @@ class StubAuthenticationLogRepository implements AuthenticationLogRepositoryInte
         return false;
     }
 
-    public function findOneByConfirmationToken(string $confirmationToken): (AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface)|null
+    public function findOneByConfirmationToken(string $confirmationToken): ?ConfirmableAuthenticationLogInterface
     {
         return null;
     }
@@ -70,7 +71,7 @@ class StubAuthenticationLogRepository implements AuthenticationLogRepositoryInte
  */
 class StubAuthenticationLogCreator implements AuthenticationLogCreatorInterface
 {
-    public function createLog(string $userIdentifier, UserInformation $userInformation): AbstractAuthenticationLog
+    public function createLog(string $userIdentifier, UserInformation $userInformation): AuthenticationLogInterface
     {
         return new class($userInformation) extends AbstractAuthenticationLog {
             public function getUser(): \Spiriit\Bundle\AuthLogBundle\Entity\AuthLogUserInterface

--- a/tests/Integration/Stubs/BundleExtension.php
+++ b/tests/Integration/Stubs/BundleExtension.php
@@ -90,12 +90,17 @@ class StubNotification implements NotificationInterface
  */
 class StubConfirmableAuthenticationLogRepository implements ConfirmableAuthenticationLogRepositoryInterface
 {
-    public function findOneByConfirmationToken(string $confirmationToken): ?ConfirmableAuthenticationLogInterface
+    public function findOneByConfirmationToken(string $confirmationToken): (AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface)|null
     {
         return null;
     }
 
-    public function save(ConfirmableAuthenticationLogInterface $authenticationLog): void
+    public function save(AbstractAuthenticationLog $log): void
     {
+    }
+
+    public function findExistingLog(string $userIdentifier, UserInformation $userInformation): bool
+    {
+        return false;
     }
 }

--- a/tests/Integration/Stubs/BundleExtension.php
+++ b/tests/Integration/Stubs/BundleExtension.php
@@ -28,26 +28,27 @@ class BundleExtension extends Extension
     {
         $repository = new Definition(StubAuthenticationLogRepository::class);
         $repository->setPublic(true);
-        $container->setDefinition(AuthenticationLogRepositoryInterface::class, $repository);
+        $repository->setAutoconfigured(true);
+        $container->setDefinition(StubAuthenticationLogRepository::class, $repository);
 
         $creator = new Definition(StubAuthenticationLogCreator::class);
         $creator->setPublic(true);
-        $container->setDefinition(AuthenticationLogCreatorInterface::class, $creator);
+        $creator->setAutoconfigured(true);
+        $container->setDefinition(StubAuthenticationLogCreator::class, $creator);
 
         $notification = new Definition(StubNotification::class);
         $notification->setPublic(true);
         $container->setDefinition('app.custom_notification', $notification);
-
-        $confirmableRepository = new Definition(StubConfirmableAuthenticationLogRepository::class);
-        $confirmableRepository->setPublic(true);
-        $container->setDefinition(ConfirmableAuthenticationLogRepositoryInterface::class, $confirmableRepository);
     }
 }
 
 /**
+ * Mirrors the README: a single repository implements every bundle interface,
+ * so autoconfiguration tags it and the bundle aliases the interfaces to it.
+ *
  * @internal
  */
-class StubAuthenticationLogRepository implements AuthenticationLogRepositoryInterface
+class StubAuthenticationLogRepository implements AuthenticationLogRepositoryInterface, ConfirmableAuthenticationLogRepositoryInterface
 {
     public function save(AbstractAuthenticationLog $log): void
     {
@@ -56,6 +57,11 @@ class StubAuthenticationLogRepository implements AuthenticationLogRepositoryInte
     public function findExistingLog(string $userIdentifier, UserInformation $userInformation): bool
     {
         return false;
+    }
+
+    public function findOneByConfirmationToken(string $confirmationToken): (AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface)|null
+    {
+        return null;
     }
 }
 
@@ -82,25 +88,5 @@ class StubNotification implements NotificationInterface
 {
     public function send(UserInformation $userInformation, UserReference $userReference, ?ConfirmationLinks $confirmationLinks = null): void
     {
-    }
-}
-
-/**
- * @internal
- */
-class StubConfirmableAuthenticationLogRepository implements ConfirmableAuthenticationLogRepositoryInterface
-{
-    public function findOneByConfirmationToken(string $confirmationToken): (AbstractAuthenticationLog&ConfirmableAuthenticationLogInterface)|null
-    {
-        return null;
-    }
-
-    public function save(AbstractAuthenticationLog $log): void
-    {
-    }
-
-    public function findExistingLog(string $userIdentifier, UserInformation $userInformation): bool
-    {
-        return false;
     }
 }

--- a/tests/Integration/Stubs/BundleExtension.php
+++ b/tests/Integration/Stubs/BundleExtension.php
@@ -10,11 +10,14 @@
 namespace Spiriit\Bundle\Tests\Integration\Stubs;
 
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogCreatorInterface;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
 use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
 use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
 use Spiriit\Bundle\AuthLogBundle\Repository\AuthenticationLogRepositoryInterface;
+use Spiriit\Bundle\AuthLogBundle\Repository\ConfirmableAuthenticationLogRepositoryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -34,6 +37,10 @@ class BundleExtension extends Extension
         $notification = new Definition(StubNotification::class);
         $notification->setPublic(true);
         $container->setDefinition('app.custom_notification', $notification);
+
+        $confirmableRepository = new Definition(StubConfirmableAuthenticationLogRepository::class);
+        $confirmableRepository->setPublic(true);
+        $container->setDefinition(ConfirmableAuthenticationLogRepositoryInterface::class, $confirmableRepository);
     }
 }
 
@@ -73,7 +80,22 @@ class StubAuthenticationLogCreator implements AuthenticationLogCreatorInterface
  */
 class StubNotification implements NotificationInterface
 {
-    public function send(UserInformation $userInformation, UserReference $userReference): void
+    public function send(UserInformation $userInformation, UserReference $userReference, ?ConfirmationLinks $confirmationLinks = null): void
+    {
+    }
+}
+
+/**
+ * @internal
+ */
+class StubConfirmableAuthenticationLogRepository implements ConfirmableAuthenticationLogRepositoryInterface
+{
+    public function findOneByConfirmationToken(string $confirmationToken): ?ConfirmableAuthenticationLogInterface
+    {
+        return null;
+    }
+
+    public function save(ConfirmableAuthenticationLogInterface $authenticationLog): void
     {
     }
 }

--- a/tests/Integration/Stubs/Kernel.php
+++ b/tests/Integration/Stubs/Kernel.php
@@ -11,6 +11,7 @@ namespace Spiriit\Bundle\Tests\Integration\Stubs;
 
 use Spiriit\Bundle\AuthLogBundle\SpiriitAuthLogBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
@@ -32,11 +33,17 @@ class Kernel extends BaseKernel
      */
     public function registerBundles(): array
     {
-        return [
+        $bundles = [
             new FrameworkBundle(),
             new SpiriitAuthLogBundle(),
             new Bundle(),
         ];
+
+        if ('confirmation' === $this->config) {
+            $bundles[] = new TwigBundle();
+        }
+
+        return $bundles;
     }
 
     /**

--- a/tests/Integration/config/confirmation_config.yaml
+++ b/tests/Integration/config/confirmation_config.yaml
@@ -1,0 +1,19 @@
+framework:
+    test: true
+    secret: secret
+    translator:
+        default_path: 'translations'
+    router:
+        resource: '%kernel.project_dir%/config/routes.php'
+        type: php
+        utf8: true
+
+twig: ~
+
+spiriit_auth_log:
+    transports:
+        sender_email: 'no-reply@yourdomain.com'
+        sender_name: 'Your App Security'
+    confirmation:
+        enabled: true
+        token_ttl: '3 days'

--- a/tests/Integration/config/invalid_ttl_config.yaml
+++ b/tests/Integration/config/invalid_ttl_config.yaml
@@ -1,0 +1,12 @@
+framework:
+    test: true
+    secret: secret
+    translator:
+        default_path: 'translations'
+
+spiriit_auth_log:
+    transports:
+        sender_email: 'no-reply@yourdomain.com'
+        sender_name: 'Your App Security'
+    confirmation:
+        token_ttl: 'not-a-duration'

--- a/tests/Listener/AuthenticationLogConfirmationEventTest.php
+++ b/tests/Listener/AuthenticationLogConfirmationEventTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\Tests\Listener;
+
+use PHPUnit\Framework\TestCase;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Listener\AuthenticationLogConfirmationEvent;
+
+final class AuthenticationLogConfirmationEventTest extends TestCase
+{
+    public function testEventExposesTheConfirmedLog(): void
+    {
+        $authenticationLog = $this->createStub(ConfirmableAuthenticationLogInterface::class);
+        $event = new AuthenticationLogConfirmationEvent($authenticationLog);
+
+        self::assertSame($authenticationLog, $event->authenticationLog());
+    }
+}

--- a/tests/Listener/LoginListenerTest.php
+++ b/tests/Listener/LoginListenerTest.php
@@ -13,11 +13,13 @@ namespace Spiriit\Bundle\Tests\Listener;
 
 use PHPUnit\Framework\TestCase;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogHandlerInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\Entity\AuthLogUserInterface;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\FetchUserInformation;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Listener\LoginListener;
 use Spiriit\Bundle\AuthLogBundle\Messenger\AuthLoginMessage\AuthLoginMessage;
+use Spiriit\Bundle\AuthLogBundle\Notification\NewDeviceNotifier;
 use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
 use Spiriit\Bundle\AuthLogBundle\Services\LoginService;
 use Symfony\Component\HttpFoundation\Request;
@@ -57,7 +59,7 @@ class LoginListenerTest extends TestCase
 
         $handler = $this->createMock(AuthenticationLogHandlerInterface::class);
         $handler->method('isKnown')->willReturn(false);
-        $handler->expects(self::once())->method('handle');
+        $handler->expects(self::once())->method('handle')->willReturn($this->createStub(AbstractAuthenticationLog::class));
 
         $notifier = $this->createMock(NotificationInterface::class);
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
@@ -67,7 +69,7 @@ class LoginListenerTest extends TestCase
             new UserInformation('127.0.0.1', 'Test Agent', new \DateTimeImmutable(), null)
         );
 
-        $loginService = new LoginService($fetchUserInformation, $handler, $notifier, $dispatcher);
+        $loginService = new LoginService($fetchUserInformation, $handler, new NewDeviceNotifier($notifier), $dispatcher);
         $listener = new LoginListener($loginService);
 
         $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
@@ -89,7 +91,7 @@ class LoginListenerTest extends TestCase
 
         $fetchUserInformation = $this->createStub(FetchUserInformation::class);
 
-        $loginService = new LoginService($fetchUserInformation, $handler, $notifier, $dispatcher);
+        $loginService = new LoginService($fetchUserInformation, $handler, new NewDeviceNotifier($notifier), $dispatcher);
         $listener = new LoginListener($loginService);
 
         $request = new Request();
@@ -112,7 +114,7 @@ class LoginListenerTest extends TestCase
 
         $fetchUserInformation = $this->createStub(FetchUserInformation::class);
 
-        $loginService = new LoginService($fetchUserInformation, $handler, $notifier, $dispatcher);
+        $loginService = new LoginService($fetchUserInformation, $handler, new NewDeviceNotifier($notifier), $dispatcher);
 
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus->expects(self::once())

--- a/tests/Messenger/AuthLoginMessageHandlerTest.php
+++ b/tests/Messenger/AuthLoginMessageHandlerTest.php
@@ -14,10 +14,12 @@ namespace Spiriit\Bundle\Tests\Messenger;
 use PHPUnit\Framework\TestCase;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogHandlerInterface;
 use Spiriit\Bundle\AuthLogBundle\DTO\LoginParameterDto;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\FetchUserInformation;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
 use Spiriit\Bundle\AuthLogBundle\Messenger\AuthLoginMessage\AuthLoginMessage;
 use Spiriit\Bundle\AuthLogBundle\Messenger\AuthLoginMessage\AuthLoginMessageHandler;
+use Spiriit\Bundle\AuthLogBundle\Notification\NewDeviceNotifier;
 use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
 use Spiriit\Bundle\AuthLogBundle\Services\LoginService;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -41,14 +43,14 @@ final class AuthLoginMessageHandlerTest extends TestCase
 
         $handler = $this->createMock(AuthenticationLogHandlerInterface::class);
         $handler->method('isKnown')->willReturn(false);
-        $handler->expects(self::once())->method('handle');
+        $handler->expects(self::once())->method('handle')->willReturn($this->createStub(AbstractAuthenticationLog::class));
 
         $notifier = $this->createMock(NotificationInterface::class);
         $notifier->expects(self::once())->method('send');
 
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
 
-        $loginService = new LoginService($fetchUserInformation, $handler, $notifier, $dispatcher);
+        $loginService = new LoginService($fetchUserInformation, $handler, new NewDeviceNotifier($notifier), $dispatcher);
         $messageHandler = new AuthLoginMessageHandler($loginService);
 
         $messageHandler(new AuthLoginMessage($dto));

--- a/tests/Notification/NewDeviceNotifierTest.php
+++ b/tests/Notification/NewDeviceNotifierTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the spiriitlabs/auth-log-bundle package.
+ * Copyright (c) SpiriitLabs <https://www.spiriit.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spiriit\Bundle\Tests\Notification;
+
+use PHPUnit\Framework\TestCase;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationLinks;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationToken;
+use Spiriit\Bundle\AuthLogBundle\Confirmation\ConfirmationUrlGenerator;
+use Spiriit\Bundle\AuthLogBundle\DTO\UserReference;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
+use Spiriit\Bundle\AuthLogBundle\Entity\AuthLogUserInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogInterface;
+use Spiriit\Bundle\AuthLogBundle\Entity\ConfirmableAuthenticationLogTrait;
+use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
+use Spiriit\Bundle\AuthLogBundle\Notification\NewDeviceNotifier;
+use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class NewDeviceNotifierTest extends TestCase
+{
+    public function testItShouldSendWithoutLinksWhenConfirmationIsDisabled(): void
+    {
+        $userInformation = $this->userInformation();
+        $userReference = $this->userReference();
+
+        $notification = $this->createMock(NotificationInterface::class);
+        $notification->expects(self::once())
+            ->method('send')
+            ->with($userInformation, $userReference, null);
+
+        $newDeviceNotifier = new NewDeviceNotifier($notification);
+
+        $newDeviceNotifier->notify($userInformation, $userReference, $this->createStub(AbstractAuthenticationLog::class));
+    }
+
+    public function testItShouldSendConfirmationLinksForAConfirmableLog(): void
+    {
+        $userInformation = $this->userInformation();
+        $userReference = $this->userReference();
+
+        $notification = $this->createMock(NotificationInterface::class);
+        $notification->expects(self::once())
+            ->method('send')
+            ->with($userInformation, $userReference, self::isInstanceOf(ConfirmationLinks::class));
+
+        $log = $this->confirmableLog();
+        $log->enableConfirmation(new ConfirmationToken('the-token'));
+
+        $newDeviceNotifier = new NewDeviceNotifier($notification, $this->confirmationUrlGenerator());
+
+        $newDeviceNotifier->notify($userInformation, $userReference, $log);
+    }
+
+    public function testItShouldSendWithoutLinksWhenLogIsNotConfirmable(): void
+    {
+        $userInformation = $this->userInformation();
+        $userReference = $this->userReference();
+
+        $notification = $this->createMock(NotificationInterface::class);
+        $notification->expects(self::once())
+            ->method('send')
+            ->with($userInformation, $userReference, null);
+
+        $newDeviceNotifier = new NewDeviceNotifier($notification, $this->confirmationUrlGenerator());
+
+        $newDeviceNotifier->notify($userInformation, $userReference, $this->createStub(AbstractAuthenticationLog::class));
+    }
+
+    private function confirmationUrlGenerator(): ConfirmationUrlGenerator
+    {
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('https://app.test/auth-log/confirm/acknowledge/the-token?expires=1');
+
+        return new ConfirmationUrlGenerator($urlGenerator, new UriSigner('a-secret'), 'spiriit_auth_log_confirm', '3 days');
+    }
+
+    private function userInformation(): UserInformation
+    {
+        return new UserInformation('127.0.0.1', 'PHPUnit', new \DateTimeImmutable(), null);
+    }
+
+    private function userReference(): UserReference
+    {
+        return new UserReference('1', 'user@test.com', 'Test User');
+    }
+
+    private function confirmableLog(): ConfirmableAuthenticationLogInterface&AbstractAuthenticationLog
+    {
+        return new class($this->userInformation()) extends AbstractAuthenticationLog implements ConfirmableAuthenticationLogInterface {
+            use ConfirmableAuthenticationLogTrait;
+
+            public function getUser(): AuthLogUserInterface
+            {
+                throw new \RuntimeException('Stub');
+            }
+        };
+    }
+}

--- a/tests/Services/LoginServiceTest.php
+++ b/tests/Services/LoginServiceTest.php
@@ -14,8 +14,10 @@ namespace Spiriit\Bundle\Tests\Services;
 use PHPUnit\Framework\TestCase;
 use Spiriit\Bundle\AuthLogBundle\AuthenticationLog\AuthenticationLogHandlerInterface;
 use Spiriit\Bundle\AuthLogBundle\DTO\LoginParameterDto;
+use Spiriit\Bundle\AuthLogBundle\Entity\AbstractAuthenticationLog;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\FetchUserInformation;
 use Spiriit\Bundle\AuthLogBundle\FetchUserInformation\UserInformation;
+use Spiriit\Bundle\AuthLogBundle\Notification\NewDeviceNotifier;
 use Spiriit\Bundle\AuthLogBundle\Notification\NotificationInterface;
 use Spiriit\Bundle\AuthLogBundle\Services\LoginService;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -41,15 +43,15 @@ class LoginServiceTest extends TestCase
         $handler = $this->createMock(AuthenticationLogHandlerInterface::class);
         $handler->method('isKnown')->willReturn(true);
 
-        $notifier = $this->createMock(NotificationInterface::class);
+        $notification = $this->createMock(NotificationInterface::class);
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         // Act
         $handler->expects(self::never())->method('handle');
-        $notifier->expects(self::never())->method('send');
+        $notification->expects(self::never())->method('send');
         $dispatcher->expects(self::never())->method('dispatch');
 
-        $service = new LoginService($fetchUserInformation, $handler, $notifier, $dispatcher);
+        $service = new LoginService($fetchUserInformation, $handler, new NewDeviceNotifier($notification), $dispatcher);
         $service->execute($dto);
     }
 
@@ -72,15 +74,15 @@ class LoginServiceTest extends TestCase
         $handler = $this->createMock(AuthenticationLogHandlerInterface::class);
         $handler->method('isKnown')->willReturn(false);
 
-        $notifier = $this->createMock(NotificationInterface::class);
+        $notification = $this->createMock(NotificationInterface::class);
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         // Act
-        $handler->expects(self::once())->method('handle');
-        $notifier->expects(self::once())->method('send');
+        $handler->expects(self::once())->method('handle')->willReturn($this->createStub(AbstractAuthenticationLog::class));
+        $notification->expects(self::once())->method('send');
         $dispatcher->expects(self::once())->method('dispatch');
 
-        $service = new LoginService($fetchUserInformation, $handler, $notifier, $dispatcher);
+        $service = new LoginService($fetchUserInformation, $handler, new NewDeviceNotifier($notification), $dispatcher);
         $service->execute($dto);
     }
 }

--- a/translations/SpiriitAuthLogBundle.en.yaml
+++ b/translations/SpiriitAuthLogBundle.en.yaml
@@ -24,6 +24,9 @@ confirmation:
         already_reviewed:
             title: 'Already handled'
             message: 'This login has already been handled. No further action is required.'
+        not_found:
+            title: 'Link no longer valid'
+            message: 'We could not find the login this link points to. It may no longer be available. If you are unsure about this login, change your password.'
         invalid:
             title: 'Invalid link'
             message: 'This link is invalid. Please use the link provided in your email.'

--- a/translations/SpiriitAuthLogBundle.en.yaml
+++ b/translations/SpiriitAuthLogBundle.en.yaml
@@ -1,2 +1,32 @@
 notification:
     subject: 'New login activity on your app'
+
+confirmation:
+    email:
+        acknowledge: 'It was me'
+        disavow: "It wasn't me"
+    show:
+        acknowledge:
+            title: 'Confirm this login'
+            message: 'You are about to confirm that this login was made by you.'
+            button: 'Yes, it was me'
+        disavow:
+            title: 'Report this login'
+            message: 'You are about to report that this login was not made by you.'
+            button: "No, it wasn't me"
+    result:
+        acknowledged:
+            title: 'Login confirmed'
+            message: 'Thank you, this login has been acknowledged as yours.'
+        disavowed:
+            title: 'Login reported'
+            message: 'Thank you, we recorded that this login was not made by you. Consider changing your password.'
+        already_reviewed:
+            title: 'Already handled'
+            message: 'This login has already been handled. No further action is required.'
+        invalid:
+            title: 'Invalid link'
+            message: 'This link is invalid. Please use the link provided in your email.'
+        expired:
+            title: 'Expired link'
+            message: 'This link has expired. If you are unsure about this login, change your password.'

--- a/translations/SpiriitAuthLogBundle.fr.yaml
+++ b/translations/SpiriitAuthLogBundle.fr.yaml
@@ -24,6 +24,9 @@ confirmation:
         already_reviewed:
             title: 'Déjà traité'
             message: "Cette connexion a déjà été traitée. Aucune action supplémentaire n'est nécessaire."
+        not_found:
+            title: 'Lien introuvable'
+            message: "Nous n'avons pas trouvé la connexion associée à ce lien. Elle n'est peut-être plus disponible. Si vous avez un doute sur cette connexion, changez votre mot de passe."
         invalid:
             title: 'Lien invalide'
             message: 'Ce lien est invalide. Veuillez utiliser le lien fourni dans votre e-mail.'

--- a/translations/SpiriitAuthLogBundle.fr.yaml
+++ b/translations/SpiriitAuthLogBundle.fr.yaml
@@ -1,2 +1,32 @@
 notification:
     subject: 'Nouvelle activité de connexion sur votre application'
+
+confirmation:
+    email:
+        acknowledge: "C'était moi"
+        disavow: "Ce n'était pas moi"
+    show:
+        acknowledge:
+            title: 'Confirmer cette connexion'
+            message: 'Vous êtes sur le point de confirmer que cette connexion vient bien de vous.'
+            button: "Oui, c'était moi"
+        disavow:
+            title: 'Signaler cette connexion'
+            message: "Vous êtes sur le point de signaler que cette connexion ne vient pas de vous."
+            button: "Non, ce n'était pas moi"
+    result:
+        acknowledged:
+            title: 'Connexion confirmée'
+            message: 'Merci, cette connexion a bien été reconnue comme la vôtre.'
+        disavowed:
+            title: 'Connexion signalée'
+            message: "Merci, nous avons enregistré que cette connexion ne venait pas de vous. Pensez à changer votre mot de passe."
+        already_reviewed:
+            title: 'Déjà traité'
+            message: 'Cette connexion a déjà été traitée. Aucune action supplémentaire n\'est nécessaire.'
+        invalid:
+            title: 'Lien invalide'
+            message: 'Ce lien est invalide. Veuillez utiliser le lien fourni dans votre e-mail.'
+        expired:
+            title: 'Lien expiré'
+            message: 'Ce lien a expiré. Si vous avez un doute sur cette connexion, changez votre mot de passe.'

--- a/translations/SpiriitAuthLogBundle.fr.yaml
+++ b/translations/SpiriitAuthLogBundle.fr.yaml
@@ -23,7 +23,7 @@ confirmation:
             message: "Merci, nous avons enregistré que cette connexion ne venait pas de vous. Pensez à changer votre mot de passe."
         already_reviewed:
             title: 'Déjà traité'
-            message: 'Cette connexion a déjà été traitée. Aucune action supplémentaire n\'est nécessaire.'
+            message: "Cette connexion a déjà été traitée. Aucune action supplémentaire n'est nécessaire."
         invalid:
             title: 'Lien invalide'
             message: 'Ce lien est invalide. Veuillez utiliser le lien fourni dans votre e-mail.'


### PR DESCRIPTION
Add an opt-in feature that appends two signed links to the new-device notification email so the user can acknowledge a login as theirs or disavow it, from any device, without being authenticated.

Design:
- The log entity owns its confirmation lifecycle via an opt-in trait + interface (ConfirmableAuthenticationLogTrait / Interface): enableConfirmation(), acknowledge(), disavow(), with a single-use invariant. Kept off the AbstractAuthenticationLog mapped superclass so integrators who don't enable the feature need no migration.
- Tokens are minted by a dedicated ConfirmationTokenGenerator and links built by ConfirmationUrlGenerator (UriSigner + expiration carried in the signed URL for 6.4→8.0 portability). MailerNotification stays decoupled from the entity and UriSigner: a cohesive NewDeviceNotifier builds the links and passes an optional ConfirmationLinks VO, keeping LoginService at 4 dependencies.
- Stateless controller (no session/CSRF): GET renders an intermediate page, POST performs the action against the same signed URL, defeating email link scanners. The action arg is a backed enum resolved/validated by Symfony.
- Bundle only records the outcome and dispatches LOGIN_ACKNOWLEDGED / LOGIN_DISAVOWED; the app decides what to do (documented example listener).